### PR TITLE
Refactor HandleFindStop into smaller, tested functions

### DIFF
--- a/handlers/voice/find_stop.go
+++ b/handlers/voice/find_stop.go
@@ -16,54 +16,88 @@ import (
 )
 
 func (h *Handler) HandleFindStop(c *gin.Context) {
+	req, ok := h.bindFindStopRequest(c)
+	if !ok {
+		return
+	}
+
+	c.Header("Content-Type", "text/xml")
+
+	// A single digit may be a selection from a pending disambiguation prompt.
+	if h.tryHandleDisambiguationChoice(c, req) {
+		return
+	}
+
+	h.SessionStore.ClearDisambiguationSession(req.From)
+
+	stopID, ok := h.resolveStopID(c, req)
+	if !ok {
+		return
+	}
+
+	h.respondForStopID(c, req, stopID)
+}
+
+// bindFindStopRequest binds and validates the incoming request. On failure it
+// writes the error response and returns ok=false.
+func (h *Handler) bindFindStopRequest(c *gin.Context) (models.TwilioVoiceRequest, bool) {
 	var req models.TwilioVoiceRequest
 	if err := c.ShouldBind(&req); err != nil {
 		language := h.getLanguageFromRequest(c)
 		h.ErrorHandler.HandleValidationError(c, err, "voice", language)
-		return
+		return req, false
 	}
 
-	// Validate phone number
 	if err := validation.ValidatePhoneNumber(req.From); err != nil {
 		language := h.getLanguageFromRequest(c)
 		h.ErrorHandler.HandleValidationError(c, err, "voice", language)
-		return
+		return req, false
 	}
 
-	// Validate call SID if provided
+	// A malformed call SID is logged but not fatal: the call can still proceed.
 	if req.CallSid != "" {
 		if err := validation.ValidateTwilioCallSid(req.CallSid); err != nil {
 			log.Printf("Invalid call SID from %s: %v", req.From, err)
 		}
 	}
 
-	// Sanitize digits input
 	req.Digits = validation.SanitizeUserInput(req.Digits)
-
 	log.Printf("Received voice input from %s: %s", req.From, req.Digits)
 
-	c.Header("Content-Type", "text/xml")
+	return req, true
+}
 
-	if choice := h.parseDisambiguationChoice(req.Digits); choice > 0 {
-		if session := h.SessionStore.GetDisambiguationSession(req.From); session != nil {
-			maxChoices := len(session.StopOptions)
-			if maxChoices > 9 {
-				maxChoices = 9
-			}
-			if err := validation.ValidateDisambiguationChoice(req.Digits, maxChoices); err != nil {
-				log.Printf("Invalid disambiguation choice from %s: %v", req.From, err)
-				language := h.getLanguageFromRequest(c)
-				errorMsg := h.LocalizationManager.GetString("voice.error.invalid_choice", language, maxChoices)
-				h.respondVoiceSay(c, language, errorMsg)
-				return
-			}
-			h.handleVoiceDisambiguationChoice(c, req, choice)
-			return
-		}
+// tryHandleDisambiguationChoice handles the digits as a choice for a pending
+// disambiguation session. It returns true when the request was handled (a
+// response was written); false means the digits should be treated as a stop ID.
+func (h *Handler) tryHandleDisambiguationChoice(c *gin.Context, req models.TwilioVoiceRequest) bool {
+	choice := h.parseDisambiguationChoice(req.Digits)
+	if choice == 0 {
+		return false
 	}
 
-	h.SessionStore.ClearDisambiguationSession(req.From)
+	session := h.SessionStore.GetDisambiguationSession(req.From)
+	if session == nil {
+		return false
+	}
 
+	maxChoices := clampChoiceCount(len(session.StopOptions))
+
+	if err := validation.ValidateDisambiguationChoice(req.Digits, maxChoices); err != nil {
+		log.Printf("Invalid disambiguation choice from %s: %v", req.From, err)
+		language := h.getLanguageFromRequest(c)
+		errorMsg := h.LocalizationManager.GetString("voice.error.invalid_choice", language, maxChoices)
+		h.respondVoiceSay(c, language, errorMsg)
+		return true
+	}
+
+	h.handleVoiceDisambiguationChoice(c, req, choice)
+	return true
+}
+
+// resolveStopID extracts and validates the stop ID from the request digits. On
+// failure it writes the error response and returns ok=false.
+func (h *Handler) resolveStopID(c *gin.Context, req models.TwilioVoiceRequest) (string, bool) {
 	stopID := req.Digits
 	if stopID == "" {
 		language := h.getLanguageFromRequest(c)
@@ -72,19 +106,23 @@ func (h *Handler) HandleFindStop(c *gin.Context) {
 			errorMsg = "I didn't receive any digits. Please try calling again."
 		}
 		h.respondVoiceSay(c, language, errorMsg)
-		return
+		return "", false
 	}
 
-	// Validate stop ID format and security
 	if err := validation.ValidateStopID(stopID); err != nil {
 		log.Printf("Invalid stop ID from %s: %s, error: %v", req.From, stopID, err)
 		language := h.getLanguageFromRequest(c)
 		errorMsg := h.LocalizationManager.GetString("voice.error.invalid_stop_id", language)
 		h.respondVoiceSay(c, language, errorMsg)
-		return
+		return "", false
 	}
 
-	// Find all matching stops for the given ID
+	return stopID, true
+}
+
+// respondForStopID looks up the stops matching stopID and responds: arrivals for
+// a single match, a disambiguation prompt for several, or an error otherwise.
+func (h *Handler) respondForStopID(c *gin.Context, req models.TwilioVoiceRequest, stopID string) {
 	matchingStops, err := h.OBAClient.FindAllMatchingStops(stopID)
 	if err != nil {
 		language := h.getLanguageFromRequest(c)
@@ -167,6 +205,18 @@ func (h *Handler) respondVoiceStopDisambiguation(c *gin.Context, fromPhone, stop
 	c.String(http.StatusOK, twimlResult)
 }
 
+// maxVoiceChoices is the most disambiguation options a caller can select, bounded
+// by the single DTMF digit (1-9) used to choose one.
+const maxVoiceChoices = 9
+
+// clampChoiceCount limits a number of options to what a single keypress can select.
+func clampChoiceCount(n int) int {
+	if n > maxVoiceChoices {
+		return maxVoiceChoices
+	}
+	return n
+}
+
 // parseDisambiguationChoice checks if the input digits represent a single-digit choice (1-9)
 func (h *Handler) parseDisambiguationChoice(digits string) int {
 	if len(digits) != 1 {
@@ -174,7 +224,7 @@ func (h *Handler) parseDisambiguationChoice(digits string) int {
 	}
 
 	choice, err := strconv.Atoi(digits)
-	if err != nil || choice < 1 || choice > 9 {
+	if err != nil || choice < 1 || choice > maxVoiceChoices {
 		return 0
 	}
 
@@ -194,10 +244,7 @@ func (h *Handler) handleVoiceDisambiguationChoice(c *gin.Context, req models.Twi
 		return
 	}
 
-	effectiveMax := len(session.StopOptions)
-	if effectiveMax > 9 {
-		effectiveMax = 9
-	}
+	effectiveMax := clampChoiceCount(len(session.StopOptions))
 
 	if choice < 1 || choice > effectiveMax {
 		language := h.getLanguageFromRequest(c)
@@ -230,17 +277,14 @@ func (h *Handler) formatVoiceDisambiguationMessage(c *gin.Context, stops []model
 	}
 
 	// Limit to first 9 options for voice interface (single digit choices)
-	maxStops := len(stops)
-	if maxStops > 9 {
-		maxStops = 9
-	}
+	maxStops := clampChoiceCount(len(stops))
 
 	for i := 0; i < maxStops; i++ {
 		stop := stops[i]
 		msg += fmt.Sprintf("Press %d for %s. ", i+1, stop.StopName)
 	}
 
-	if len(stops) > 9 {
+	if len(stops) > maxVoiceChoices {
 		msg += "Only showing first 9 options. "
 	}
 

--- a/handlers/voice/find_stop.go
+++ b/handlers/voice/find_stop.go
@@ -285,7 +285,7 @@ func (h *Handler) formatVoiceDisambiguationMessage(c *gin.Context, stops []model
 	}
 
 	if len(stops) > maxVoiceChoices {
-		msg += "Only showing first 9 options. "
+		msg += fmt.Sprintf("Only showing first %d options. ", maxVoiceChoices)
 	}
 
 	msg += "Which stop would you like?"

--- a/handlers/voice/find_stop_test.go
+++ b/handlers/voice/find_stop_test.go
@@ -114,6 +114,7 @@ func TestHandleFindStop_InvalidPhoneNumber(t *testing.T) {
 
 	// Phone validation fails before any OBA lookup happens.
 	mockClient.AssertNotCalled(t, "FindAllMatchingStops", mock.Anything)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.NotEqual(t, "", w.Body.String())
 }
 
@@ -325,5 +326,8 @@ func TestGetAndFormatVoiceArrivals_LookupError(t *testing.T) {
 
 	h.getAndFormatVoiceArrivalsWithSession(c, "+14444444444", "1_12345", 0)
 
+	// A lookup failure should render a spoken error response, not just stop short.
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "<Say")
 	mockClient.AssertExpectations(t)
 }

--- a/handlers/voice/find_stop_test.go
+++ b/handlers/voice/find_stop_test.go
@@ -1,0 +1,329 @@
+package voice
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"oba-twilio/localization"
+	"oba-twilio/models"
+)
+
+// mockOBAClient is a testify mock implementing client.OneBusAwayClientInterface.
+type mockOBAClient struct {
+	mock.Mock
+}
+
+func (m *mockOBAClient) GetArrivalsAndDepartures(stopID string) (*models.OneBusAwayResponse, error) {
+	args := m.Called(stopID)
+	resp, _ := args.Get(0).(*models.OneBusAwayResponse)
+	return resp, args.Error(1)
+}
+
+func (m *mockOBAClient) GetArrivalsAndDeparturesWithWindow(stopID string, minutesAfter int) (*models.OneBusAwayResponse, error) {
+	args := m.Called(stopID, minutesAfter)
+	resp, _ := args.Get(0).(*models.OneBusAwayResponse)
+	return resp, args.Error(1)
+}
+
+func (m *mockOBAClient) ProcessArrivals(resp *models.OneBusAwayResponse, maxMinutesOut int) []models.Arrival {
+	args := m.Called(resp, maxMinutesOut)
+	arrivals, _ := args.Get(0).([]models.Arrival)
+	return arrivals
+}
+
+func (m *mockOBAClient) SearchStops(query string) ([]models.Stop, error) {
+	args := m.Called(query)
+	stops, _ := args.Get(0).([]models.Stop)
+	return stops, args.Error(1)
+}
+
+func (m *mockOBAClient) InitializeCoverage() error {
+	return m.Called().Error(0)
+}
+
+func (m *mockOBAClient) GetCoverageArea() *models.CoverageArea {
+	args := m.Called()
+	area, _ := args.Get(0).(*models.CoverageArea)
+	return area
+}
+
+func (m *mockOBAClient) FindAllMatchingStops(stopID string) ([]models.StopOption, error) {
+	args := m.Called(stopID)
+	stops, _ := args.Get(0).([]models.StopOption)
+	return stops, args.Error(1)
+}
+
+func (m *mockOBAClient) GetStopInfo(fullStopID string) (*models.StopOption, error) {
+	args := m.Called(fullStopID)
+	stop, _ := args.Get(0).(*models.StopOption)
+	return stop, args.Error(1)
+}
+
+// newArrivalsResponse builds a minimal OneBusAwayResponse carrying the given stop ID.
+func newArrivalsResponse(stopID string) *models.OneBusAwayResponse {
+	resp := &models.OneBusAwayResponse{Code: 200}
+	resp.Data.Entry.StopId = stopID
+	return resp
+}
+
+// expectSingleStopArrivals wires the four mock calls a successful single-stop
+// lookup makes: resolve digits -> fullStopID, then fetch and format its arrivals.
+func expectSingleStopArrivals(mockClient *mockOBAClient, digits, fullStopID, route string) {
+	stops := []models.StopOption{{FullStopID: fullStopID, StopName: "Test Stop"}}
+	resp := newArrivalsResponse(fullStopID)
+	mockClient.On("FindAllMatchingStops", digits).Return(stops, nil)
+	mockClient.On("GetArrivalsAndDeparturesWithWindow", fullStopID, 30).Return(resp, nil)
+	mockClient.On("ProcessArrivals", resp, mock.Anything).Return([]models.Arrival{{RouteShortName: route, MinutesUntilArrival: 5}})
+	mockClient.On("GetStopInfo", fullStopID).Return(&stops[0], nil)
+}
+
+func setupFindStopHandler() (*gin.Engine, *mockOBAClient, *Handler) {
+	gin.SetMode(gin.TestMode)
+	mockClient := &mockOBAClient{}
+	h := NewHandler(mockClient, localization.NewTestManager())
+
+	r := gin.New()
+	r.POST("/voice/find_stop", h.HandleFindStop)
+	return r, mockClient, h
+}
+
+func postFindStop(r *gin.Engine, from, digits string) *httptest.ResponseRecorder {
+	form := url.Values{}
+	form.Set("From", from)
+	form.Set("Digits", digits)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/voice/find_stop", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestHandleFindStop_InvalidPhoneNumber(t *testing.T) {
+	r, mockClient, _ := setupFindStopHandler()
+
+	w := postFindStop(r, "abc", "12345")
+
+	// Phone validation fails before any OBA lookup happens.
+	mockClient.AssertNotCalled(t, "FindAllMatchingStops", mock.Anything)
+	assert.NotEqual(t, "", w.Body.String())
+}
+
+func TestHandleFindStop_InvalidCallSidStillProceeds(t *testing.T) {
+	r, mockClient, _ := setupFindStopHandler()
+
+	expectSingleStopArrivals(mockClient, "12345", "1_12345", "8")
+
+	form := url.Values{}
+	form.Set("From", "+14444444444")
+	form.Set("Digits", "12345")
+	form.Set("CallSid", "not-a-valid-sid")
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/voice/find_stop", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "Route 8")
+	mockClient.AssertExpectations(t)
+}
+
+func TestHandleFindStop_EmptyDigits(t *testing.T) {
+	r, _, _ := setupFindStopHandler()
+
+	w := postFindStop(r, "+14444444444", "")
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "receive any digits")
+}
+
+func TestHandleFindStop_InvalidStopIDFormat(t *testing.T) {
+	r, mockClient, _ := setupFindStopHandler()
+
+	// 21 characters exceeds the 20-char stop ID limit, so it fails format validation.
+	w := postFindStop(r, "+14444444444", "123456789012345678901")
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "Invalid stop ID")
+	mockClient.AssertNotCalled(t, "FindAllMatchingStops", mock.Anything)
+}
+
+func TestHandleFindStop_LookupError(t *testing.T) {
+	r, mockClient, _ := setupFindStopHandler()
+
+	mockClient.On("FindAllMatchingStops", "12345").Return(nil, fmt.Errorf("boom"))
+
+	w := postFindStop(r, "+14444444444", "12345")
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	mockClient.AssertExpectations(t)
+}
+
+func TestHandleFindStop_NoMatchingStops(t *testing.T) {
+	r, mockClient, _ := setupFindStopHandler()
+
+	mockClient.On("FindAllMatchingStops", "12345").Return([]models.StopOption{}, nil)
+
+	w := postFindStop(r, "+14444444444", "12345")
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "find any stops")
+	mockClient.AssertExpectations(t)
+}
+
+func TestHandleFindStop_MultipleStopsPromptsDisambiguation(t *testing.T) {
+	r, mockClient, _ := setupFindStopHandler()
+
+	stops := []models.StopOption{
+		{FullStopID: "1_999", StopName: "Pine Street"},
+		{FullStopID: "40_999", StopName: "Oak Avenue"},
+	}
+	mockClient.On("FindAllMatchingStops", "999").Return(stops, nil)
+
+	w := postFindStop(r, "+14444444444", "999")
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "<Gather")
+	assert.Contains(t, body, "Press 1 for Pine Street")
+	assert.Contains(t, body, "Press 2 for Oak Avenue")
+	mockClient.AssertExpectations(t)
+}
+
+func TestHandleFindStop_SingleStopReturnsArrivals(t *testing.T) {
+	r, mockClient, _ := setupFindStopHandler()
+
+	expectSingleStopArrivals(mockClient, "12345", "1_12345", "8")
+
+	w := postFindStop(r, "+14444444444", "12345")
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "Route 8")
+	mockClient.AssertExpectations(t)
+}
+
+func TestHandleFindStop_MoreThanNineStopsClampsToNine(t *testing.T) {
+	r, mockClient, _ := setupFindStopHandler()
+
+	// Twelve matches exceed the single-DTMF-digit ceiling, so only the first
+	// nine are offered (clampChoiceCount) and the caller is told so.
+	stops := make([]models.StopOption, 12)
+	for i := range stops {
+		stops[i] = models.StopOption{
+			FullStopID: fmt.Sprintf("1_%d", i+1),
+			StopName:   fmt.Sprintf("Stop %d", i+1),
+		}
+	}
+	mockClient.On("FindAllMatchingStops", "999").Return(stops, nil)
+
+	w := postFindStop(r, "+14444444444", "999")
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "Press 9 for Stop 9")
+	assert.NotContains(t, body, "Press 10 for")
+	assert.Contains(t, body, "Only showing first 9 options")
+	mockClient.AssertExpectations(t)
+}
+
+func TestHandleFindStop_DisambiguationChoiceSelectsStop(t *testing.T) {
+	r, mockClient, _ := setupFindStopHandler()
+
+	stops := []models.StopOption{
+		{FullStopID: "1_999", StopName: "Pine Street"},
+		{FullStopID: "40_999", StopName: "Oak Avenue"},
+	}
+	resp := newArrivalsResponse("40_999")
+	mockClient.On("FindAllMatchingStops", "999").Return(stops, nil).Once()
+	mockClient.On("GetArrivalsAndDeparturesWithWindow", "40_999", 30).Return(resp, nil).Once()
+	mockClient.On("ProcessArrivals", resp, mock.Anything).Return([]models.Arrival{{RouteShortName: "99", MinutesUntilArrival: 4}})
+	mockClient.On("GetStopInfo", "40_999").Return(&stops[1], nil)
+
+	phone := "+16667778899"
+	require.Equal(t, http.StatusOK, postFindStop(r, phone, "999").Code)
+
+	w := postFindStop(r, phone, "2")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "Route 99")
+	mockClient.AssertExpectations(t)
+}
+
+func TestHandleFindStop_DisambiguationChoiceOutOfRange(t *testing.T) {
+	r, mockClient, _ := setupFindStopHandler()
+
+	stops := []models.StopOption{
+		{FullStopID: "1_999", StopName: "Pine Street"},
+		{FullStopID: "40_999", StopName: "Oak Avenue"},
+	}
+	mockClient.On("FindAllMatchingStops", "999").Return(stops, nil).Once()
+
+	phone := "+16667779900"
+	require.Equal(t, http.StatusOK, postFindStop(r, phone, "999").Code)
+
+	// Choice 9 exceeds the 2 available options.
+	w := postFindStop(r, phone, "9")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "Please press a number between 1 and 2")
+	mockClient.AssertExpectations(t)
+}
+
+func TestHandleFindStop_SingleDigitWithoutSessionTreatedAsStopID(t *testing.T) {
+	r, mockClient, _ := setupFindStopHandler()
+
+	expectSingleStopArrivals(mockClient, "1", "1_1", "8")
+
+	w := postFindStop(r, "+14444444444", "1")
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "Route 8")
+	assert.NotContains(t, w.Body.String(), "No active selection")
+	mockClient.AssertExpectations(t)
+}
+
+func TestParseDisambiguationChoice(t *testing.T) {
+	h := NewHandler(&mockOBAClient{}, localization.NewTestManager())
+
+	assert.Equal(t, 0, h.parseDisambiguationChoice(""))
+	assert.Equal(t, 0, h.parseDisambiguationChoice("12"))
+	assert.Equal(t, 0, h.parseDisambiguationChoice("0"))
+	assert.Equal(t, 0, h.parseDisambiguationChoice("a"))
+	assert.Equal(t, 5, h.parseDisambiguationChoice("5"))
+	assert.Equal(t, 9, h.parseDisambiguationChoice("9"))
+}
+
+func TestHandleVoiceDisambiguationChoice_NoSession(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := NewHandler(&mockOBAClient{}, localization.NewTestManager())
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequest("POST", "/voice/find_stop", nil)
+
+	h.handleVoiceDisambiguationChoice(c, models.TwilioVoiceRequest{From: "+14444444444"}, 1)
+
+	assert.Contains(t, w.Body.String(), "No active selection")
+}
+
+func TestGetAndFormatVoiceArrivals_LookupError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	mockClient := &mockOBAClient{}
+	h := NewHandler(mockClient, localization.NewTestManager())
+
+	mockClient.On("GetArrivalsAndDeparturesWithWindow", "1_12345", 30).Return(nil, fmt.Errorf("boom"))
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequest("POST", "/voice/find_stop", nil)
+
+	h.getAndFormatVoiceArrivalsWithSession(c, "+14444444444", "1_12345", 0)
+
+	mockClient.AssertExpectations(t)
+}


### PR DESCRIPTION
Closes #1

## Summary
- Split the ~93-line `HandleFindStop` (`handlers/voice/find_stop.go`) into four focused helpers — `bindFindStopRequest`, `tryHandleDisambiguationChoice`, `resolveStopID`, `respondForStopID` — reducing the handler itself to a 22-line top-to-bottom pipeline: bind → maybe-handle-disambiguation → resolve stop ID → respond.
- Replaced the magic `9` DTMF ceiling (open-coded in 4 places) with a `maxVoiceChoices` const and a `clampChoiceCount` helper.
- Added in-package characterization tests (`handlers/voice/find_stop_test.go`, package `voice`) covering every branch. Combined with the existing `handlers`-package tests, `HandleFindStop` is at **100%** statement coverage and the extracted helpers are well covered (80–100%).
- **Behavior is unchanged** — pure refactor. The decomposition was verified line-by-line against the original, including the subtle "single digit with no active session falls through to be treated as a stop ID" path.

## Test plan
- [x] `make fmt` / `make vet` / `make lint` (0 issues) / `make test` all pass
- [x] Golden path: single-stop match → arrivals + menu TwiML
- [x] Disambiguation: multiple matches prompt, choice selects a stop, out-of-range choice rejected
- [x] Edge cases: invalid phone (short-circuits before lookup), invalid call SID (non-fatal), empty digits, invalid stop-ID format, lookup error, zero matches, single-digit-without-session, >9 matches clamp to 9

## Review notes (non-blocking follow-ups, intentionally out of scope here)
- `bindFindStopRequest` overlaps with the existing `preprocessRequest` helper, but they are **not** interchangeable: `preprocessRequest` also fires analytics (`TrackVoiceRequest`), which the original `HandleFindStop` never did. Unifying them is a deliberate behavior decision (should find-stop calls be tracked?) — left for a follow-up to keep this PR behavior-preserving.
- `handleVoiceDisambiguationChoice` still re-fetches the session and re-validates the choice range that `tryHandleDisambiguationChoice` already checked; that downstream range check is now effectively unreachable on the real path (a pre-existing redundancy, not introduced here). Could be collapsed by passing the session through.
- The new `voice`-package tests overlap with several `HandleFindStop` cases in `handlers/voice_menu_test.go`, which could be retired in favor of these.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved voice stop search reliability with stronger request validation and clearer error handling.
  * Refined disambiguation flow for multiple matching stops, consistently limiting prompts to the first nine options.
  * Enhanced stop ID resolution, including better handling of missing/invalid digit inputs.
* **Tests**
  * Added a comprehensive unit test suite for voice stop search, covering invalid inputs, lookup failures, no matches, single- and multi-stop disambiguation, and option clamping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->