### PR TITLE
refactor: replace magic session numbers with sessionType

### DIFF
--- a/handlers/common/session_store.go
+++ b/handlers/common/session_store.go
@@ -23,6 +23,14 @@ const (
 // Accept E.164 numbers used by Twilio (e.g. +14445556666, +48500100200).
 var phoneRegex = regexp.MustCompile(`^\+[1-9]\d{7,14}$`)
 
+type SessionType int
+
+const (
+	Disambiguation SessionType = iota
+	Voice
+	Sms
+)
+
 // SessionMetrics provides insights into session store performance
 type SessionMetrics struct {
 	TotalSessions   int64
@@ -37,7 +45,7 @@ type SessionMetrics struct {
 
 // SessionEntry represents a session with metadata for efficient LRU management
 type SessionEntry struct {
-	sessionType int // 0=disambiguation, 1=voice, 2=sms
+	sessionType SessionType // 0=disambiguation, 1=voice, 2=sms
 	data        interface{}
 	createdAt   int64
 	accessedAt  int64
@@ -216,9 +224,9 @@ func (s *ImprovedSessionStore) validateSession(phoneNumber string, entry *Sessio
 	var timeout int64
 
 	switch entry.sessionType {
-	case 0, 1: // disambiguation, voice
+	case Disambiguation, Voice: // disambiguation, voice
 		timeout = SessionTimeoutMinutes * 60
-	case 2: // SMS
+	case Sms: // SMS
 		timeout = smsSessionTimeoutMinutes * 60
 	default:
 		return false
@@ -256,7 +264,7 @@ func (s *ImprovedSessionStore) evictLRUSessions(count int) {
 }
 
 // setSession is a generic method to set any type of session
-func (s *ImprovedSessionStore) setSession(phoneNumber string, data interface{}, sessionType int) error {
+func (s *ImprovedSessionStore) setSession(phoneNumber string, data interface{}, sessionType SessionType) error {
 	if !phoneRegex.MatchString(phoneNumber) {
 		return fmt.Errorf("invalid phone number format: %s", phoneNumber)
 	}
@@ -281,15 +289,15 @@ func (s *ImprovedSessionStore) setSession(phoneNumber string, data interface{}, 
 
 	// Set timestamps based on session type
 	switch sessionType {
-	case 0: // disambiguation
+	case Disambiguation:
 		if ds, ok := data.(*models.DisambiguationSession); ok {
 			ds.CreatedAt = now
 		}
-	case 1: // voice
+	case Voice:
 		if vs, ok := data.(*models.VoiceSession); ok {
 			vs.CreatedAt = now
 		}
-	case 2: // SMS
+	case Sms:
 		if ss, ok := data.(*models.SMSSession); ok {
 			ss.CreatedAt = now
 			ss.LastQueryTime = now
@@ -307,7 +315,7 @@ func (s *ImprovedSessionStore) setSession(phoneNumber string, data interface{}, 
 }
 
 // getSession is a generic method to get any type of session
-func (s *ImprovedSessionStore) getSession(phoneNumber string, sessionType int) interface{} {
+func (s *ImprovedSessionStore) getSession(phoneNumber string, sessionType SessionType) interface{} {
 	if !phoneRegex.MatchString(phoneNumber) {
 		return nil
 	}
@@ -354,11 +362,11 @@ func (s *ImprovedSessionStore) clearSession(phoneNumber string) {
 
 // Public API methods for disambiguation sessions
 func (s *ImprovedSessionStore) SetDisambiguationSession(phoneNumber string, session *models.DisambiguationSession) error {
-	return s.setSession(phoneNumber, session, 0)
+	return s.setSession(phoneNumber, session, Disambiguation)
 }
 
 func (s *ImprovedSessionStore) GetDisambiguationSession(phoneNumber string) *models.DisambiguationSession {
-	if data := s.getSession(phoneNumber, 0); data != nil {
+	if data := s.getSession(phoneNumber, Disambiguation); data != nil {
 		return data.(*models.DisambiguationSession)
 	}
 	return nil
@@ -370,11 +378,11 @@ func (s *ImprovedSessionStore) ClearDisambiguationSession(phoneNumber string) {
 
 // Public API methods for voice sessions
 func (s *ImprovedSessionStore) SetVoiceSession(phoneNumber string, session *models.VoiceSession) error {
-	return s.setSession(phoneNumber, session, 1)
+	return s.setSession(phoneNumber, session, Voice)
 }
 
 func (s *ImprovedSessionStore) GetVoiceSession(phoneNumber string) *models.VoiceSession {
-	if data := s.getSession(phoneNumber, 1); data != nil {
+	if data := s.getSession(phoneNumber, Voice); data != nil {
 		return data.(*models.VoiceSession)
 	}
 	return nil
@@ -386,11 +394,11 @@ func (s *ImprovedSessionStore) ClearVoiceSession(phoneNumber string) {
 
 // Public API methods for SMS sessions
 func (s *ImprovedSessionStore) SetSMSSession(phoneNumber string, session *models.SMSSession) error {
-	return s.setSession(phoneNumber, session, 2)
+	return s.setSession(phoneNumber, session, Sms)
 }
 
 func (s *ImprovedSessionStore) GetSMSSession(phoneNumber string) *models.SMSSession {
-	if data := s.getSession(phoneNumber, 2); data != nil {
+	if data := s.getSession(phoneNumber, Sms); data != nil {
 		return data.(*models.SMSSession)
 	}
 	return nil
@@ -454,13 +462,13 @@ func (s *ImprovedSessionStore) estimateMemoryUsage() int64 {
 	// Add estimated size of session data
 	for _, entry := range s.sessions {
 		switch entry.sessionType {
-		case 0: // disambiguation
+		case Disambiguation:
 			if ds, ok := entry.data.(*models.DisambiguationSession); ok {
 				baseSize += int64(len(ds.StopOptions) * 100) // rough estimate per stop option
 			}
-		case 1: // voice
+		case Voice:
 			baseSize += 100 // voice sessions are small
-		case 2: // SMS
+		case Sms:
 			baseSize += 200 // SMS sessions with language strings
 		}
 	}
@@ -546,24 +554,24 @@ func (s *ImprovedSessionStore) ExpireSession(phoneNumber string) {
 		// Set the creation time to an expired timestamp based on session type
 		var timeout int64
 		switch entry.sessionType {
-		case 0, 1: // disambiguation, voice
+		case Disambiguation, Voice: // disambiguation, voice
 			timeout = (SessionTimeoutMinutes + 1) * 60
-		case 2: // SMS
+		case Sms: // SMS
 			timeout = (smsSessionTimeoutMinutes + 1) * 60
 		}
 		entry.createdAt = time.Now().Unix() - timeout
 
 		// Update the session data timestamp as well
 		switch entry.sessionType {
-		case 0: // disambiguation
+		case Disambiguation:
 			if ds, ok := entry.data.(*models.DisambiguationSession); ok {
 				ds.CreatedAt = entry.createdAt
 			}
-		case 1: // voice
+		case Voice:
 			if vs, ok := entry.data.(*models.VoiceSession); ok {
 				vs.CreatedAt = entry.createdAt
 			}
-		case 2: // SMS
+		case Sms:
 			if ss, ok := entry.data.(*models.SMSSession); ok {
 				ss.CreatedAt = entry.createdAt
 			}
@@ -584,7 +592,7 @@ func (s *ImprovedSessionStore) SetExpiredSMSSession(phoneNumber string, session 
 	session.CreatedAt = expiredTime
 
 	entry := &SessionEntry{
-		sessionType: 2, // SMS
+		sessionType: Sms,
 		data:        session,
 		createdAt:   expiredTime,
 		accessedAt:  expiredTime,

--- a/handlers/common/session_store.go
+++ b/handlers/common/session_store.go
@@ -23,12 +23,24 @@ const (
 // Accept E.164 numbers used by Twilio (e.g. +14445556666, +48500100200).
 var phoneRegex = regexp.MustCompile(`^\+[1-9]\d{7,14}$`)
 
-type SessionType int
+type sessionCategory int
+
+func (s sessionCategory) String() string {
+	switch s {
+	case disambiguation:
+		return "disambiguation"
+	case voice:
+		return "voice"
+	case sms:
+		return "sms"
+	}
+	return "unknown"
+}
 
 const (
-	Disambiguation SessionType = iota
-	Voice
-	Sms
+	disambiguation sessionCategory = iota
+	voice
+	sms
 )
 
 // SessionMetrics provides insights into session store performance
@@ -45,7 +57,7 @@ type SessionMetrics struct {
 
 // SessionEntry represents a session with metadata for efficient LRU management
 type SessionEntry struct {
-	sessionType SessionType // 0=disambiguation, 1=voice, 2=sms
+	sessionType sessionCategory
 	data        interface{}
 	createdAt   int64
 	accessedAt  int64
@@ -224,9 +236,9 @@ func (s *ImprovedSessionStore) validateSession(phoneNumber string, entry *Sessio
 	var timeout int64
 
 	switch entry.sessionType {
-	case Disambiguation, Voice: // disambiguation, voice
+	case disambiguation, voice:
 		timeout = SessionTimeoutMinutes * 60
-	case Sms: // SMS
+	case sms:
 		timeout = smsSessionTimeoutMinutes * 60
 	default:
 		return false
@@ -264,7 +276,7 @@ func (s *ImprovedSessionStore) evictLRUSessions(count int) {
 }
 
 // setSession is a generic method to set any type of session
-func (s *ImprovedSessionStore) setSession(phoneNumber string, data interface{}, sessionType SessionType) error {
+func (s *ImprovedSessionStore) setSession(phoneNumber string, data interface{}, sessionType sessionCategory) error {
 	if !phoneRegex.MatchString(phoneNumber) {
 		return fmt.Errorf("invalid phone number format: %s", phoneNumber)
 	}
@@ -289,15 +301,15 @@ func (s *ImprovedSessionStore) setSession(phoneNumber string, data interface{}, 
 
 	// Set timestamps based on session type
 	switch sessionType {
-	case Disambiguation:
+	case disambiguation:
 		if ds, ok := data.(*models.DisambiguationSession); ok {
 			ds.CreatedAt = now
 		}
-	case Voice:
+	case voice:
 		if vs, ok := data.(*models.VoiceSession); ok {
 			vs.CreatedAt = now
 		}
-	case Sms:
+	case sms:
 		if ss, ok := data.(*models.SMSSession); ok {
 			ss.CreatedAt = now
 			ss.LastQueryTime = now
@@ -315,7 +327,7 @@ func (s *ImprovedSessionStore) setSession(phoneNumber string, data interface{}, 
 }
 
 // getSession is a generic method to get any type of session
-func (s *ImprovedSessionStore) getSession(phoneNumber string, sessionType SessionType) interface{} {
+func (s *ImprovedSessionStore) getSession(phoneNumber string, sessionType sessionCategory) interface{} {
 	if !phoneRegex.MatchString(phoneNumber) {
 		return nil
 	}
@@ -362,11 +374,11 @@ func (s *ImprovedSessionStore) clearSession(phoneNumber string) {
 
 // Public API methods for disambiguation sessions
 func (s *ImprovedSessionStore) SetDisambiguationSession(phoneNumber string, session *models.DisambiguationSession) error {
-	return s.setSession(phoneNumber, session, Disambiguation)
+	return s.setSession(phoneNumber, session, disambiguation)
 }
 
 func (s *ImprovedSessionStore) GetDisambiguationSession(phoneNumber string) *models.DisambiguationSession {
-	if data := s.getSession(phoneNumber, Disambiguation); data != nil {
+	if data := s.getSession(phoneNumber, disambiguation); data != nil {
 		return data.(*models.DisambiguationSession)
 	}
 	return nil
@@ -378,11 +390,11 @@ func (s *ImprovedSessionStore) ClearDisambiguationSession(phoneNumber string) {
 
 // Public API methods for voice sessions
 func (s *ImprovedSessionStore) SetVoiceSession(phoneNumber string, session *models.VoiceSession) error {
-	return s.setSession(phoneNumber, session, Voice)
+	return s.setSession(phoneNumber, session, voice)
 }
 
 func (s *ImprovedSessionStore) GetVoiceSession(phoneNumber string) *models.VoiceSession {
-	if data := s.getSession(phoneNumber, Voice); data != nil {
+	if data := s.getSession(phoneNumber, voice); data != nil {
 		return data.(*models.VoiceSession)
 	}
 	return nil
@@ -394,11 +406,11 @@ func (s *ImprovedSessionStore) ClearVoiceSession(phoneNumber string) {
 
 // Public API methods for SMS sessions
 func (s *ImprovedSessionStore) SetSMSSession(phoneNumber string, session *models.SMSSession) error {
-	return s.setSession(phoneNumber, session, Sms)
+	return s.setSession(phoneNumber, session, sms)
 }
 
 func (s *ImprovedSessionStore) GetSMSSession(phoneNumber string) *models.SMSSession {
-	if data := s.getSession(phoneNumber, Sms); data != nil {
+	if data := s.getSession(phoneNumber, sms); data != nil {
 		return data.(*models.SMSSession)
 	}
 	return nil
@@ -462,13 +474,13 @@ func (s *ImprovedSessionStore) estimateMemoryUsage() int64 {
 	// Add estimated size of session data
 	for _, entry := range s.sessions {
 		switch entry.sessionType {
-		case Disambiguation:
+		case disambiguation:
 			if ds, ok := entry.data.(*models.DisambiguationSession); ok {
 				baseSize += int64(len(ds.StopOptions) * 100) // rough estimate per stop option
 			}
-		case Voice:
+		case voice:
 			baseSize += 100 // voice sessions are small
-		case Sms:
+		case sms:
 			baseSize += 200 // SMS sessions with language strings
 		}
 	}
@@ -554,24 +566,24 @@ func (s *ImprovedSessionStore) ExpireSession(phoneNumber string) {
 		// Set the creation time to an expired timestamp based on session type
 		var timeout int64
 		switch entry.sessionType {
-		case Disambiguation, Voice: // disambiguation, voice
+		case disambiguation, voice:
 			timeout = (SessionTimeoutMinutes + 1) * 60
-		case Sms: // SMS
+		case sms:
 			timeout = (smsSessionTimeoutMinutes + 1) * 60
 		}
 		entry.createdAt = time.Now().Unix() - timeout
 
 		// Update the session data timestamp as well
 		switch entry.sessionType {
-		case Disambiguation:
+		case disambiguation:
 			if ds, ok := entry.data.(*models.DisambiguationSession); ok {
 				ds.CreatedAt = entry.createdAt
 			}
-		case Voice:
+		case voice:
 			if vs, ok := entry.data.(*models.VoiceSession); ok {
 				vs.CreatedAt = entry.createdAt
 			}
-		case Sms:
+		case sms:
 			if ss, ok := entry.data.(*models.SMSSession); ok {
 				ss.CreatedAt = entry.createdAt
 			}
@@ -592,7 +604,7 @@ func (s *ImprovedSessionStore) SetExpiredSMSSession(phoneNumber string, session 
 	session.CreatedAt = expiredTime
 
 	entry := &SessionEntry{
-		sessionType: Sms,
+		sessionType: sms,
 		data:        session,
 		createdAt:   expiredTime,
 		accessedAt:  expiredTime,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved session handling by introducing typed session discriminators (disambiguation, voice, SMS) instead of raw integer values.
  * Updated all related session-expiration, timestamp backfilling, retrieval matching, and memory estimation logic to use the new typed categories.
  * Kept existing public APIs for setting and getting disambiguation, voice, and SMS sessions unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->