### PR TITLE
refactor: hash phone numbers in logs

### DIFF
--- a/handlers/sms.go
+++ b/handlers/sms.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"oba-twilio/analytics"
 	"regexp"
 	"strconv"
 	"strings"
@@ -85,7 +86,7 @@ func (h *SMSHandler) HandleSMS(c *gin.Context) {
 	// Sanitize the message body
 	req.Body = validation.SanitizeUserInput(req.Body)
 
-	log.Printf("Received SMS from %s: %s", req.From, req.Body)
+	log.Printf("Received SMS from %s: %s", analytics.HashPhoneNumber(req.From, h.analyticsHashSalt), req.Body)
 
 	c.Header("Content-Type", "text/xml")
 
@@ -109,7 +110,7 @@ func (h *SMSHandler) HandleSMS(c *gin.Context) {
 		session := h.SessionStore.GetDisambiguationSession(req.From)
 		if session != nil {
 			if err := validation.ValidateDisambiguationChoice(req.Body, len(session.StopOptions)); err != nil {
-				log.Printf("Invalid disambiguation choice from %s: %v", req.From, err)
+				log.Printf("Invalid disambiguation choice from %s: %v", analytics.HashPhoneNumber(req.From, h.analyticsHashSalt), err)
 				errorMsg := h.LocalizationManager.GetString("sms.error.invalid_choice", h.getLanguageForUser(req.From), len(session.StopOptions))
 				twiml, _ := formatters.GenerateTwiMLSMS(errorMsg)
 				c.String(http.StatusOK, twiml)
@@ -139,7 +140,7 @@ func (h *SMSHandler) HandleSMS(c *gin.Context) {
 	smsSession.ArrivalHorizonShownMinutes = 0 // new stop query — show nearest slice from scratch
 	smsSession.LastQueryTime = time.Now().Unix()
 	if err := h.SessionStore.SetSMSSession(req.From, smsSession); err != nil {
-		log.Printf("Failed to set SMS session for %s: %v", req.From, err)
+		log.Printf("Failed to set SMS session for %s: %v", analytics.HashPhoneNumber(req.From, h.analyticsHashSalt), err)
 	}
 
 	// Find all matching stops for the given ID
@@ -222,7 +223,7 @@ func (h *SMSHandler) handleDisambiguationChoice(c *gin.Context, req models.Twili
 	selectedStop := session.StopOptions[choice-1]
 	h.SessionStore.ClearDisambiguationSession(req.From)
 
-	log.Printf("User %s selected stop %s: %s", req.From, selectedStop.FullStopID, selectedStop.DisplayText)
+	log.Printf("User %s selected stop %s: %s", analytics.HashPhoneNumber(req.From, h.analyticsHashSalt), selectedStop.FullStopID, selectedStop.DisplayText)
 
 	// Track disambiguation selection
 	if h.analyticsManager != nil {
@@ -283,7 +284,7 @@ func (h *SMSHandler) getAndFormatArrivalsWithStopNameAndSession(c *gin.Context, 
 	}
 	log.Printf(
 		"SMS pagination for %s: stop=%s window=%d total_arrivals=%d excluded=%d fallback=%t offset=%d page_size=%d returned=%d",
-		phoneNumber,
+		analytics.HashPhoneNumber(phoneNumber, h.analyticsHashSalt),
 		fullStopID,
 		window,
 		len(arrivalsAll),
@@ -340,7 +341,7 @@ func (h *SMSHandler) getAndFormatArrivalsWithStopNameAndSession(c *gin.Context, 
 	newSession.ArrivalHorizonShownMinutes = offset + len(arrivals)
 	if err := h.SessionStore.SetSMSSession(phoneNumber, &newSession); err != nil {
 		// Log error but still send the response
-		log.Printf("Failed to set SMS session for %s: %v", phoneNumber, err)
+		log.Printf("Failed to set SMS session for %s: %v", analytics.HashPhoneNumber(phoneNumber, h.analyticsHashSalt), err)
 	} else {
 		*session = newSession
 	}
@@ -418,7 +419,7 @@ func (h *SMSHandler) handleMoreRequest(c *gin.Context, req models.TwilioSMSReque
 	updatedSession.LastQueryTime = time.Now().Unix()
 	if err := h.SessionStore.SetSMSSession(req.From, &updatedSession); err != nil {
 		// Log error but continue to send response
-		log.Printf("Failed to set SMS session for %s: %v", req.From, err)
+		log.Printf("Failed to set SMS session for %s: %v", analytics.HashPhoneNumber(req.From, h.analyticsHashSalt), err)
 	} else {
 		*session = updatedSession
 	}
@@ -451,7 +452,7 @@ func (h *SMSHandler) handleLanguageSwitching(c *gin.Context, req models.TwilioSM
 	if newLang, found := languageMap[message]; found && h.LocalizationManager.IsSupported(newLang) {
 		session.Language = newLang
 		if err := h.SessionStore.SetSMSSession(req.From, session); err != nil {
-			log.Printf("Failed to set SMS session for %s: %v", req.From, err)
+			log.Printf("Failed to set SMS session for %s: %v", analytics.HashPhoneNumber(req.From, h.analyticsHashSalt), err)
 		}
 		switchedMsg := h.LocalizationManager.GetString("sms.language.switched", newLang)
 		twiml, _ := formatters.GenerateTwiMLSMS(switchedMsg)
@@ -500,7 +501,7 @@ func (h *SMSHandler) handleTimeQuery(c *gin.Context, req models.TwilioSMSRequest
 		updatedSession.LastQueryTime = time.Now().Unix()
 		if err := h.SessionStore.SetSMSSession(req.From, &updatedSession); err != nil {
 			// Log error but continue to send response
-			log.Printf("Failed to set SMS session for %s: %v", req.From, err)
+			log.Printf("Failed to set SMS session for %s: %v", analytics.HashPhoneNumber(req.From, h.analyticsHashSalt), err)
 		} else {
 			*session = updatedSession
 		}

--- a/handlers/voice/find_stop.go
+++ b/handlers/voice/find_stop.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"oba-twilio/analytics"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
@@ -57,12 +58,12 @@ func (h *Handler) bindFindStopRequest(c *gin.Context) (models.TwilioVoiceRequest
 	// A malformed call SID is logged but not fatal: the call can still proceed.
 	if req.CallSid != "" {
 		if err := validation.ValidateTwilioCallSid(req.CallSid); err != nil {
-			log.Printf("Invalid call SID from %s: %v", req.From, err)
+			log.Printf("Invalid call SID from %s: %v", analytics.HashPhoneNumber(req.From, h.analyticsHashSalt), err)
 		}
 	}
 
 	req.Digits = validation.SanitizeUserInput(req.Digits)
-	log.Printf("Received voice input from %s: %s", req.From, req.Digits)
+	log.Printf("Received voice input from %s: %s", analytics.HashPhoneNumber(req.From, h.analyticsHashSalt), req.Digits)
 
 	return req, true
 }
@@ -84,7 +85,7 @@ func (h *Handler) tryHandleDisambiguationChoice(c *gin.Context, req models.Twili
 	maxChoices := clampChoiceCount(len(session.StopOptions))
 
 	if err := validation.ValidateDisambiguationChoice(req.Digits, maxChoices); err != nil {
-		log.Printf("Invalid disambiguation choice from %s: %v", req.From, err)
+		log.Printf("Invalid disambiguation choice from %s: %v", analytics.HashPhoneNumber(req.From, h.analyticsHashSalt), err)
 		language := h.getLanguageFromRequest(c)
 		errorMsg := h.LocalizationManager.GetString("voice.error.invalid_choice", language, maxChoices)
 		h.respondVoiceSay(c, language, errorMsg)
@@ -110,7 +111,7 @@ func (h *Handler) resolveStopID(c *gin.Context, req models.TwilioVoiceRequest) (
 	}
 
 	if err := validation.ValidateStopID(stopID); err != nil {
-		log.Printf("Invalid stop ID from %s: %s, error: %v", req.From, stopID, err)
+		log.Printf("Invalid stop ID from %s: %s, error: %v", analytics.HashPhoneNumber(req.From, h.analyticsHashSalt), stopID, err)
 		language := h.getLanguageFromRequest(c)
 		errorMsg := h.LocalizationManager.GetString("voice.error.invalid_stop_id", language)
 		h.respondVoiceSay(c, language, errorMsg)
@@ -259,7 +260,7 @@ func (h *Handler) handleVoiceDisambiguationChoice(c *gin.Context, req models.Twi
 	selectedStop := session.StopOptions[choice-1]
 	h.SessionStore.ClearDisambiguationSession(req.From)
 
-	log.Printf("User %s selected stop %s: %s", req.From, selectedStop.FullStopID, selectedStop.DisplayText)
+	log.Printf("User %s selected stop %s: %s", analytics.HashPhoneNumber(req.From, h.analyticsHashSalt), selectedStop.FullStopID, selectedStop.DisplayText)
 
 	h.getAndFormatVoiceArrivalsWithSession(c, req.From, selectedStop.FullStopID, 0)
 }
@@ -335,13 +336,13 @@ func (h *Handler) getAndFormatVoiceArrivalsWithSession(c *gin.Context, phoneNumb
 	language := h.getLanguageFromRequest(c)
 	log.Printf(
 		"Formatting voice response for %s: stop=%s, arrivals=%d, excluded=%d, fallback=%t",
-		phoneNumber, stopName, len(arrivals), excluded, fallbackUsed,
+		analytics.HashPhoneNumber(phoneNumber, h.analyticsHashSalt), stopName, len(arrivals), excluded, fallbackUsed,
 	)
 
 	message := formatters.FormatVoiceResponse(arrivals, stopName, h.LocalizationManager, language)
-	log.Printf("Voice message for %s: %s", phoneNumber, message)
+	log.Printf("Voice message for %s: %s", analytics.HashPhoneNumber(phoneNumber, h.analyticsHashSalt), message)
 	if message == "" {
-		log.Printf("Empty voice response generated for %s", phoneNumber)
+		log.Printf("Empty voice response generated for %s", analytics.HashPhoneNumber(phoneNumber, h.analyticsHashSalt))
 		language := h.getLanguageFromRequest(c)
 		h.ErrorHandler.HandleVoiceError(c, fmt.Errorf("failed to format voice response"), language)
 		return
@@ -353,11 +354,11 @@ func (h *Handler) getAndFormatVoiceArrivalsWithSession(c *gin.Context, phoneNumb
 		MinutesAfter: minutesAfter,
 	}
 	if err := h.SessionStore.SetVoiceSession(phoneNumber, session); err != nil {
-		log.Printf("Failed to set voice session for %s: %v", phoneNumber, err)
+		log.Printf("Failed to set voice session for %s: %v", analytics.HashPhoneNumber(phoneNumber, h.analyticsHashSalt), err)
 	}
 	menuPrompt := h.LocalizationManager.GetString("voice.menu.more_departures", language) + " " + h.LocalizationManager.GetString("voice.menu.main_menu", language)
 
-	log.Printf("Rendering TwiML for %s with message length: %d", phoneNumber, len(message))
+	log.Printf("Rendering TwiML for %s with message length: %d", analytics.HashPhoneNumber(phoneNumber, h.analyticsHashSalt), len(message))
 
 	// Create TwiML elements
 	var elements []twiml.Element
@@ -394,7 +395,7 @@ func (h *Handler) getAndFormatVoiceArrivalsWithSession(c *gin.Context, phoneNumb
 
 	// Generate TwiML
 	if twimlResult, err := twiml.Voice(elements); err != nil {
-		log.Printf("Failed to generate TwiML for %s: %v", phoneNumber, err)
+		log.Printf("Failed to generate TwiML for %s: %v", analytics.HashPhoneNumber(phoneNumber, h.analyticsHashSalt), err)
 		errorMsg := h.LocalizationManager.GetString("voice.error.template_failed", language)
 
 		// Try to generate error response
@@ -403,7 +404,7 @@ func (h *Handler) getAndFormatVoiceArrivalsWithSession(c *gin.Context, phoneNumb
 			Language: language,
 		}
 		if errorTwiml, err2 := twiml.Voice([]twiml.Element{errorSay}); err2 != nil {
-			log.Printf("Failed to generate error TwiML for %s: %v", phoneNumber, err2)
+			log.Printf("Failed to generate error TwiML for %s: %v", analytics.HashPhoneNumber(phoneNumber, h.analyticsHashSalt), err2)
 			// Use absolute fallback
 			fallback := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?><Response><Say>%s</Say></Response>`, errorMsg)
 			c.String(http.StatusOK, fallback)
@@ -412,7 +413,7 @@ func (h *Handler) getAndFormatVoiceArrivalsWithSession(c *gin.Context, phoneNumb
 		}
 		return
 	} else {
-		log.Printf("Generated TwiML for %s, length: %d", phoneNumber, len(twimlResult))
+		log.Printf("Generated TwiML for %s, length: %d", analytics.HashPhoneNumber(phoneNumber, h.analyticsHashSalt), len(twimlResult))
 		// Log first 500 chars of TwiML for debugging
 		if len(twimlResult) > 500 {
 			log.Printf("TwiML content preview: %s...", twimlResult[:500])

--- a/handlers/voice/menu_action.go
+++ b/handlers/voice/menu_action.go
@@ -3,6 +3,7 @@ package voice
 import (
 	"log"
 	"net/http"
+	"oba-twilio/analytics"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
@@ -19,7 +20,7 @@ func (h *Handler) HandleVoiceMenuAction(c *gin.Context) {
 		return
 	}
 
-	log.Printf("Received voice menu action from %s: %s", req.From, req.Digits)
+	log.Printf("Received voice menu action from %s: %s", analytics.HashPhoneNumber(req.From, h.analyticsHashSalt), req.Digits)
 
 	c.Header("Content-Type", "text/xml")
 
@@ -61,7 +62,7 @@ func (h *Handler) handleExtendDepartures(c *gin.Context, req models.TwilioVoiceR
 	// Get minutesAfter from query parameter
 	minutesAfterStr := c.Query("minutesAfter")
 	if minutesAfterStr == "" {
-		log.Printf("Missing minutesAfter parameter in request from %s", req.From)
+		log.Printf("Missing minutesAfter parameter in request from %s", analytics.HashPhoneNumber(req.From, h.analyticsHashSalt))
 		language := h.getLanguageFromRequest(c)
 		errorMsg := h.LocalizationManager.GetString("error.internal_error", language)
 		if errorMsg == "" {
@@ -81,7 +82,7 @@ func (h *Handler) handleExtendDepartures(c *gin.Context, req models.TwilioVoiceR
 
 	newMinutesAfter, err := strconv.Atoi(minutesAfterStr)
 	if err != nil {
-		log.Printf("Invalid minutesAfter parameter: %s from %s", minutesAfterStr, req.From)
+		log.Printf("Invalid minutesAfter parameter: %s from %s", minutesAfterStr, analytics.HashPhoneNumber(req.From, h.analyticsHashSalt))
 		language := h.getLanguageFromRequest(c)
 		errorMsg := h.LocalizationManager.GetString("error.internal_error", language)
 		if errorMsg == "" {
@@ -102,7 +103,7 @@ func (h *Handler) handleExtendDepartures(c *gin.Context, req models.TwilioVoiceR
 	// Update the session
 	session.MinutesAfter = newMinutesAfter
 	if err := h.SessionStore.SetVoiceSession(req.From, session); err != nil {
-		log.Printf("Failed to update voice session for %s: %v", req.From, err)
+		log.Printf("Failed to update voice session for %s: %v", analytics.HashPhoneNumber(req.From, h.analyticsHashSalt), err)
 		language := h.getLanguageFromRequest(c)
 		errorMsg := h.LocalizationManager.GetString("error.internal_error", language)
 		if errorMsg == "" {
@@ -120,7 +121,7 @@ func (h *Handler) handleExtendDepartures(c *gin.Context, req models.TwilioVoiceR
 		return
 	}
 
-	log.Printf("Extended departures window for %s to %d minutes", req.From, newMinutesAfter)
+	log.Printf("Extended departures window for %s to %d minutes", analytics.HashPhoneNumber(req.From, h.analyticsHashSalt), newMinutesAfter)
 
 	// Get arrivals with extended window
 	h.getAndFormatVoiceArrivalsWithSession(c, req.From, session.StopID, newMinutesAfter)
@@ -129,7 +130,7 @@ func (h *Handler) handleExtendDepartures(c *gin.Context, req models.TwilioVoiceR
 // handleReturnToMainMenu clears the voice session and returns to the start menu
 func (h *Handler) handleReturnToMainMenu(c *gin.Context, req models.TwilioVoiceRequest) {
 	h.SessionStore.ClearVoiceSession(req.From)
-	log.Printf("Cleared voice session for %s, returning to main menu", req.From)
+	log.Printf("Cleared voice session for %s, returning to main menu", analytics.HashPhoneNumber(req.From, h.analyticsHashSalt))
 	h.returnToMainMenu(c)
 }
 

--- a/handlers/voice/start.go
+++ b/handlers/voice/start.go
@@ -2,9 +2,11 @@ package voice
 
 import (
 	"fmt"
-	"github.com/twilio/twilio-go/twiml"
 	"log/slog"
 	"net/http"
+	"oba-twilio/analytics"
+
+	"github.com/twilio/twilio-go/twiml"
 
 	"github.com/gin-gonic/gin"
 )
@@ -18,7 +20,7 @@ func (h *Handler) HandleVoiceStart(c *gin.Context) {
 
 	language := h.getLanguageFromRequest(c)
 
-	slog.Info("Received voice call", "from", req.From, "callSid", req.CallSid)
+	slog.Info("Received voice call", "from", analytics.HashPhoneNumber(req.From, h.analyticsHashSalt), "callSid", req.CallSid)
 
 	h.renderMainMenuWithLanguage(c, language)
 }


### PR DESCRIPTION
closes #10 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Security**
  * Phone numbers are now hashed in system logs across messaging (SMS) and voice call handlers, preventing raw caller/sender numbers from appearing in audit logs while keeping log detail useful for monitoring and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->