### PR TITLE
Add CI workflow for formatting, lint, and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+env:
+  GO_VERSION: "1.24.2"
+
+jobs:
+  format:
+    name: Check formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Verify gofmt
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "The following files are not formatted (run 'make fmt'):"
+            echo "$unformatted"
+            exit 1
+          fi
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: go test
+        run: go test -short ./...


### PR DESCRIPTION
## Summary

Adds a GitHub Actions CI workflow (`.github/workflows/ci.yml`) that runs on every pull request and on pushes to `main`. It performs three checks as **separate, independent jobs**, so each appears as its own discrete status check and fails fast on its own:

- **Check formatting** — `gofmt -l .` fails if any file is unformatted
- **Lint** — `golangci-lint` (official action)
- **Test** — `go test -short ./...`

## Notes

- Go is pinned to `1.24.2` (matching `go.mod`) via a single `GO_VERSION` env var.
- Tests run with `-short` to skip the live OneBusAway API integration tests, which require a real `ONEBUSAWAY_API_KEY` and would otherwise be flaky in CI. If we want those to run, we can inject the key from a repo secret instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)