### PR TITLE
Allow "test" and other non-empty ONEBUSAWAY_API_KEY values (fixes #11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Create a `.env` file or set environment variables:
 | **Server Configuration** | | | |
 | `PORT` | Server port number | `8080` | Optional |
 | **OneBusAway API Configuration** | | | |
-| `ONEBUSAWAY_API_KEY` | API key for OneBusAway server | `test` | Required |
+| `ONEBUSAWAY_API_KEY` | API key for OneBusAway server (no default; `test` is the public demo key for the Puget Sound server and works for local development) | - | Required |
 | `ONEBUSAWAY_BASE_URL` | OneBusAway API base URL | `https://api.pugetsound.onebusaway.org` | Optional |
 | **Localization** | | | |
 | `SUPPORTED_LANGUAGES` | Comma-separated list of supported language codes | `en-US` | Optional |
@@ -344,7 +344,7 @@ echo "web: ./oba-twilio" > Procfile
 
 # Deploy
 heroku create your-app-name
-heroku config:set ONEBUSAWAY_API_KEY=test
+heroku config:set ONEBUSAWAY_API_KEY=your_actual_api_key
 git push heroku main
 ```
 

--- a/config_test.go
+++ b/config_test.go
@@ -118,18 +118,23 @@ func TestAPIKeyValidation(t *testing.T) {
 		shouldFail bool
 	}{
 		{"Empty key should fail", "", true},
-		{"Test key should fail", "test", true},
-		{"TEST key should fail", "TEST", true},
-		{"Placeholder should fail", "placeholder", true},
+		{"Test key should pass", "test", false},
+		{"TEST key should pass", "TEST", false},
+		// "placeholder" was rejected before the issue #11 fix; any non-empty
+		// value is now accepted, so it must pass.
+		{"Placeholder should now pass", "placeholder", false},
 		{"Valid key should pass", "valid-api-key", false},
 		{"OneBusAway key should pass", "org.onebusaway.iphone", false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Test the validation logic without calling log.Fatal
-			isInvalid := tt.apiKey == "" || tt.apiKey == "test" || tt.apiKey == "TEST" || tt.apiKey == "placeholder"
-			assert.Equal(t, tt.shouldFail, isInvalid)
+			err := validateAPIKey(tt.apiKey)
+			if tt.shouldFail {
+				assert.ErrorContains(t, err, "ONEBUSAWAY_API_KEY")
+			} else {
+				assert.NoError(t, err)
+			}
 		})
 	}
 }

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"log"
 	"os"
 	"os/signal"
@@ -23,6 +24,20 @@ import (
 	"oba-twilio/middleware"
 )
 
+// validateAPIKey ensures an OneBusAway API key was explicitly provided. The key
+// is required and has intentionally no default, so the server won't silently
+// start with no credentials. Only an empty value is rejected; any non-empty
+// value is accepted, including "test" — the public demo key for the Puget Sound
+// OneBusAway server, valid for local development. (An earlier check that also
+// rejected "test"/"placeholder" was removed: it broke that documented workflow.
+// See issue #11.)
+func validateAPIKey(apiKey string) error {
+	if apiKey == "" {
+		return errors.New("ONEBUSAWAY_API_KEY environment variable is required but not set")
+	}
+	return nil
+}
+
 func main() {
 	if err := godotenv.Load(); err != nil {
 		log.Println("No .env file found, using environment variables")
@@ -34,11 +49,8 @@ func main() {
 	}
 
 	obaAPIKey := os.Getenv("ONEBUSAWAY_API_KEY")
-	if obaAPIKey == "" {
-		log.Fatal("ONEBUSAWAY_API_KEY environment variable is required but not set")
-	}
-	if obaAPIKey == "test" || obaAPIKey == "TEST" || obaAPIKey == "placeholder" {
-		log.Fatal("Invalid API key detected. Please set a valid ONEBUSAWAY_API_KEY environment variable")
+	if err := validateAPIKey(obaAPIKey); err != nil {
+		log.Fatal(err)
 	}
 
 	obaBaseURL := os.Getenv("ONEBUSAWAY_BASE_URL")


### PR DESCRIPTION
## Summary
- Fixes #11. The startup validation rejected `ONEBUSAWAY_API_KEY` values of `test`/`TEST`/`placeholder`, but `test` is the legitimate public demo key for the Puget Sound OneBusAway server (and is documented in the README), so the documented local-dev workflow couldn't actually run.
- Removes the over-aggressive value blocklist while **preserving the real security fix**: the key is still required (no silent fallback to a default). Validation is extracted into a small `validateAPIKey` helper so the existing `TestAPIKeyValidation` exercises real code instead of duplicating the check inline.
- Doc fixes: corrected the README env-var table (no default; `test` noted as the demo key) and replaced `test` with a real-key placeholder in the production Heroku deploy example.

## Test plan
- [x] `make fmt`, `make vet`, `make lint` (0 issues), `make test` / `go test ./... -short` — all pass
- [x] Built the binary and ran with **empty** key → fatals with `ONEBUSAWAY_API_KEY environment variable is required but not set`
- [x] Ran with `ONEBUSAWAY_API_KEY=test` → server boots, `/health` returns 200, and it successfully fetched real coverage data from the Puget Sound API using the `test` key (confirming it's a working local-dev key)
- [x] `TestAPIKeyValidation` updated: empty → error (asserts the message names the env var); `test`/`TEST`/`placeholder`/valid keys → accepted

## Review notes (non-blocking)
- A literal `placeholder` value now passes startup validation and would instead fail at the **first OneBusAway API request** rather than at boot. This is a deliberate trade-off — the blocklist's purpose (preventing the documented `test` key) was the bug. The OBA client surfaces auth failures on the request path, so a bad key fails loudly per-request, not silently. If fast-fail-at-startup for obvious placeholders is desired, that's a separate product decision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration guidance to mark `ONEBUSAWAY_API_KEY` as required with no default value. Updated Heroku deployment instructions accordingly.

* **Changes**
  * Modified API key validation to enforce the required configuration setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->