### PR TITLE
feat: add centralize hashing for analytics and phone logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,40 +224,42 @@ curl -X POST \
 
 Create a `.env` file or set environment variables:
 
-| Variable | Description | Default Value | Required/Optional |
-|----------|-------------|---------------|-------------------|
-| **Server Configuration** | | | |
-| `PORT` | Server port number | `8080` | Optional |
-| **OneBusAway API Configuration** | | | |
-| `ONEBUSAWAY_API_KEY` | API key for OneBusAway server (no default; `test` is the public demo key for the Puget Sound server and works for local development) | - | Required |
-| `ONEBUSAWAY_BASE_URL` | OneBusAway API base URL | `https://api.pugetsound.onebusaway.org` | Optional |
-| **Localization** | | | |
-| `SUPPORTED_LANGUAGES` | Comma-separated list of supported language codes | `en-US` | Optional |
-| **Twilio Configuration** | | | |
-| `TWILIO_ACCOUNT_SID` | Twilio account SID (for outbound features) | - | Optional |
-| `TWILIO_AUTH_TOKEN` | Twilio auth token (for outbound features) | - | Optional |
-| **Analytics Configuration** | | | |
-| `ANALYTICS_ENABLED` | Enable/disable analytics collection | `false` | Optional |
-| `ANALYTICS_HASH_SALT` | Salt for hashing sensitive analytics data (32+ char random string) | - | Required if analytics enabled |
-| `ANALYTICS_WORKER_COUNT` | Number of analytics worker threads | `4` | Optional |
-| `ANALYTICS_QUEUE_SIZE` | Size of analytics event queue | `1000` | Optional |
-| `ANALYTICS_SHUTDOWN_TIMEOUT` | Timeout for analytics shutdown (seconds) | `30` | Optional |
-| **Plausible Analytics Provider** | | | |
-| `PLAUSIBLE_ENABLED` | Enable/disable Plausible analytics provider | `false` | Optional |
-| `PLAUSIBLE_DOMAIN` | Domain for Plausible analytics tracking | - | Required if Plausible enabled |
-| `PLAUSIBLE_API_URL` | Custom Plausible API URL | `https://plausible.io` | Optional |
-| `PLAUSIBLE_API_KEY` | Plausible API key (for custom domains) | - | Optional |
-| `PLAUSIBLE_BATCH_SIZE` | Batch size for Plausible events | `50` | Optional |
-| `PLAUSIBLE_FLUSH_INTERVAL` | Flush interval for Plausible events (seconds) | `30` | Optional |
-| `PLAUSIBLE_HTTP_TIMEOUT` | HTTP timeout for Plausible requests (seconds) | `10` | Optional |
-| `PLAUSIBLE_MAX_RETRIES` | Maximum retries for failed Plausible requests | `3` | Optional |
-| `PLAUSIBLE_RETRY_DELAY` | Delay between Plausible retries (seconds) | `1` | Optional |
-| **Umami Analytics Provider** | | | |
-| `UMAMI_ENABLED` | Enable the Umami analytics provider | `false` | Optional |
-| `UMAMI_URL` | Umami host; events POST to `<UMAMI_URL>/api/send` | - | Required if Umami enabled |
-| `UMAMI_WEBSITE_ID` | Umami website UUID | - | Required if Umami enabled |
-| `UMAMI_HOSTNAME` | `hostname` field in emitted events (default: host of `ONEBUSAWAY_BASE_URL`, else `twilio.onebusaway.org`) | - | Optional |
-| `UMAMI_HTTP_TIMEOUT` | Per-request timeout, Go duration (e.g. `5s`, `10s`) | `5s` | Optional |
+| Variable                            | Description                                                                                                            | Default Value                           | Required/Optional             |
+|-------------------------------------|------------------------------------------------------------------------------------------------------------------------|-----------------------------------------|-------------------------------|
+| **Server Configuration**            |                                                                                                                        |                                         |                               |
+| `PORT`                              | Server port number                                                                                                     | `8080`                                  | Optional                      |
+| **OneBusAway API Configuration**    |                                                                                                                        |                                         |                               |
+| `ONEBUSAWAY_API_KEY`                | API key for OneBusAway server (no default; `test` is the public demo key for the Puget Sound server and works for local development) | -                                       | Required                      |
+| `ONEBUSAWAY_BASE_URL`               | OneBusAway API base URL                                                                                                | `https://api.pugetsound.onebusaway.org` | Optional                      |
+| **Localization**                    |                                                                                                                        |                                         |                               |
+| `SUPPORTED_LANGUAGES`               | Comma-separated list of supported language codes                                                                       | `en-US`                                 | Optional                      |
+| **Twilio Configuration**            |                                                                                                                        |                                         |                               |
+| `TWILIO_ACCOUNT_SID`                | Twilio account SID (for outbound features)                                                                             | -                                       | Optional                      |
+| `TWILIO_AUTH_TOKEN`                 | Twilio auth token (for outbound features)                                                                              | -                                       | Optional                      |
+| **Salts Configuration for hashing** |                                                                                                                        |                                         |                               |
+| `ANALYTICS_HASH_SALT`               | Salt for hashing sensitive analytics data (32+ char random string)                                                     | -                                       | Required if analytics enabled |
+|`PHONE_LOGS_SALT`| Salt used when hashing phone numbers before they are written to logs                                                   | -                                       | Optional                      |
+| **Analytics Configuration**         |                                                                                                                        |                                         |                               |
+| `ANALYTICS_ENABLED`                 | Enable/disable analytics collection                                                                                    | `false`                                 | Optional                      |
+| `ANALYTICS_WORKER_COUNT`            | Number of analytics worker threads                                                                                     | `4`                                     | Optional                      |
+| `ANALYTICS_QUEUE_SIZE`              | Size of analytics event queue                                                                                          | `1000`                                  | Optional                      |
+| `ANALYTICS_SHUTDOWN_TIMEOUT`        | Timeout for analytics shutdown (seconds)                                                                               | `30`                                    | Optional                      |
+| **Plausible Analytics Provider**    |                                                                                                                        |                                         |                               |
+| `PLAUSIBLE_ENABLED`                 | Enable/disable Plausible analytics provider                                                                            | `false`                                 | Optional                      |
+| `PLAUSIBLE_DOMAIN`                  | Domain for Plausible analytics tracking                                                                                | -                                       | Required if Plausible enabled |
+| `PLAUSIBLE_API_URL`                 | Custom Plausible API URL                                                                                               | `https://plausible.io`                  | Optional                      |
+| `PLAUSIBLE_API_KEY`                 | Plausible API key (for custom domains)                                                                                 | -                                       | Optional                      |
+| `PLAUSIBLE_BATCH_SIZE`              | Batch size for Plausible events                                                                                        | `50`                                    | Optional                      |
+| `PLAUSIBLE_FLUSH_INTERVAL`          | Flush interval for Plausible events (seconds)                                                                          | `30`                                    | Optional                      |
+| `PLAUSIBLE_HTTP_TIMEOUT`            | HTTP timeout for Plausible requests (seconds)                                                                          | `10`                                    | Optional                      |
+| `PLAUSIBLE_MAX_RETRIES`             | Maximum retries for failed Plausible requests                                                                          | `3`                                     | Optional                      |
+| `PLAUSIBLE_RETRY_DELAY`             | Delay between Plausible retries (seconds)                                                                              | `1`                                     | Optional                      |
+| **Umami Analytics Provider**        |                                                                                                                        |                                         |                               |
+| `UMAMI_ENABLED`                     | Enable the Umami analytics provider                                                                                    | `false`                                 | Optional                      |
+| `UMAMI_URL`                         | Umami host; events POST to `<UMAMI_URL>/api/send`                                                                      | -                                       | Required if Umami enabled     |
+| `UMAMI_WEBSITE_ID`                  | Umami website UUID                                                                                                     | -                                       | Required if Umami enabled     |
+| `UMAMI_HOSTNAME`                    | `hostname` field in emitted events (default: host of `ONEBUSAWAY_BASE_URL`, else `twilio.onebusaway.org`)              | -                                       | Optional                      |
+| `UMAMI_HTTP_TIMEOUT`                | Per-request timeout, Go duration (e.g. `5s`, `10s`)                                                                    | `5s`                                    | Optional                      |
 
 > **Note**: Analytics is API-driven (no JS tracker); the Umami provider POSTs events server-side with a browser-shaped User-Agent.
 
@@ -286,6 +288,8 @@ ANALYTICS_ENABLED=true
 # - pwgen -s 32 1
 ANALYTICS_HASH_SALT=kJ8Q2m5bC9tL3nP7sR4wX6aY1dF0eG2h
 
+PHONE_LOGS_SALT=8b7f4b73b1178857cafa12695b7dc4b9
+
 # Plausible Analytics (optional)
 PLAUSIBLE_ENABLED=true
 PLAUSIBLE_DOMAIN=your-domain.com
@@ -293,7 +297,7 @@ PLAUSIBLE_DOMAIN=your-domain.com
 
 ### Creating a Secure Hash Salt
 
-The `ANALYTICS_HASH_SALT` is used to anonymize sensitive data like phone numbers before storing them in analytics. To generate a secure salt:
+The `ANALYTICS_HASH_SALT` and `PHONE_LOGS_SALT` is used to anonymize sensitive data like phone numbers before storing them in analytics or logging them. To generate a secure salt:
 
 **Option 1: Using OpenSSL (recommended)**
 ```bash

--- a/analytics/README.md
+++ b/analytics/README.md
@@ -33,9 +33,11 @@ The package defines several standard event types:
 ## Usage
 
 ```go
+// Create a Hasher
+h := privacy.NewHasher(analyticsSalt,logSalt)
 // Create an event
 event := analytics.SMSRequestEvent(
-    analytics.HashPhoneNumber(phoneNumber, salt),
+    h.ConstructUserId(phoneNumber),
     "en-US",
     "75403",
 )

--- a/analytics/events.go
+++ b/analytics/events.go
@@ -1,8 +1,6 @@
 package analytics
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"time"
 
 	"github.com/google/uuid"
@@ -68,17 +66,6 @@ func NewEventWithSession(name string, userID string, sessionID string) Event {
 	event := NewEvent(name, userID)
 	event.SessionID = sessionID
 	return event
-}
-
-// HashPhoneNumber creates a privacy-preserving hash of a phone number.
-// It uses SHA256 with a salt to prevent rainbow table attacks.
-func HashPhoneNumber(phoneNumber string, salt string) string {
-	if phoneNumber == "" {
-		return ""
-	}
-	h := sha256.New()
-	h.Write([]byte(phoneNumber + salt))
-	return hex.EncodeToString(h.Sum(nil))
 }
 
 // SMSRequestEvent creates an event for incoming SMS requests.

--- a/analytics/events_test.go
+++ b/analytics/events_test.go
@@ -35,57 +35,6 @@ func TestNewEventWithSession(t *testing.T) {
 	assert.NotNil(t, event.Properties)
 }
 
-func TestHashPhoneNumber(t *testing.T) {
-	tests := []struct {
-		name        string
-		phoneNumber string
-		salt        string
-		want        string
-	}{
-		{
-			name:        "valid phone number",
-			phoneNumber: "+12065551234",
-			salt:        "test-salt",
-			want:        "6e7c4e6f5a6b8d9f6e5c4b3a2e1f0d9c8b7a6e5d4c3b2a1f0e9d8c7b6a5e4d3c",
-		},
-		{
-			name:        "empty phone number",
-			phoneNumber: "",
-			salt:        "test-salt",
-			want:        "",
-		},
-		{
-			name:        "different salt produces different hash",
-			phoneNumber: "+12065551234",
-			salt:        "different-salt",
-			want:        "different-hash",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := HashPhoneNumber(tt.phoneNumber, tt.salt)
-
-			if tt.phoneNumber == "" {
-				assert.Empty(t, result)
-			} else {
-				assert.NotEmpty(t, result)
-				assert.Len(t, result, 64) // SHA256 produces 64 character hex string
-
-				// Verify same input produces same output
-				result2 := HashPhoneNumber(tt.phoneNumber, tt.salt)
-				assert.Equal(t, result, result2)
-
-				// Verify different salt produces different hash
-				if tt.name == "different salt produces different hash" {
-					result3 := HashPhoneNumber(tt.phoneNumber, "test-salt")
-					assert.NotEqual(t, result, result3)
-				}
-			}
-		})
-	}
-}
-
 func TestSMSRequestEvent(t *testing.T) {
 	event := SMSRequestEvent("user-hash", "es-US", "75403")
 

--- a/handlers/disambiguation_test.go
+++ b/handlers/disambiguation_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"oba-twilio/privacy"
 	"strings"
 	"testing"
 
@@ -115,7 +116,7 @@ func setupDisambiguationTestRouter() (*gin.Engine, *MockOneBusAwayClientDisambig
 
 	mockClient := &MockOneBusAwayClientDisambiguation{}
 	locManager := localization.NewTestManager()
-	smsHandler := NewSMSHandler(mockClient, locManager)
+	smsHandler := NewSMSHandler(mockClient, locManager, privacy.NewHasher("", ""))
 
 	r := gin.New()
 	r.POST("/sms", smsHandler.HandleSMS)

--- a/handlers/sms.go
+++ b/handlers/sms.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"oba-twilio/analytics"
+	"oba-twilio/privacy"
 	"regexp"
 	"strconv"
 	"strings"
@@ -37,10 +37,10 @@ type SMSHandler struct {
 	ErrorHandler        *common.ErrorHandler
 	arrivalFilterConfig common.ArrivalFilterConfig
 	analyticsManager    middleware.AnalyticsManager
-	analyticsHashSalt   string
+	phoneHasher         *privacy.Hasher
 }
 
-func NewSMSHandler(obaClient client.OneBusAwayClientInterface, locManager *localization.LocalizationManager) *SMSHandler {
+func NewSMSHandler(obaClient client.OneBusAwayClientInterface, locManager *localization.LocalizationManager, phoneHasher *privacy.Hasher) *SMSHandler {
 	return &SMSHandler{
 		OBAClient:           obaClient,
 		SessionStore:        common.NewSessionStore(),
@@ -51,6 +51,7 @@ func NewSMSHandler(obaClient client.OneBusAwayClientInterface, locManager *local
 			MaxPredictedEarlyMins: 15,
 			FallbackToUnfiltered:  true,
 		},
+		phoneHasher: phoneHasher,
 	}
 }
 
@@ -86,7 +87,7 @@ func (h *SMSHandler) HandleSMS(c *gin.Context) {
 	// Sanitize the message body
 	req.Body = validation.SanitizeUserInput(req.Body)
 
-	log.Printf("Received SMS from %s: %s", analytics.HashPhoneNumber(req.From, h.analyticsHashSalt), req.Body)
+	log.Printf("Received SMS from %s: %s", h.phoneHasher.HashForLogs(req.From), req.Body)
 
 	c.Header("Content-Type", "text/xml")
 
@@ -95,7 +96,8 @@ func (h *SMSHandler) HandleSMS(c *gin.Context) {
 
 	// Track SMS request
 	if h.analyticsManager != nil {
-		middleware.TrackSMSRequest(c.Request.Context(), h.analyticsManager, req.From, smsSession.Language, req.Body, h.analyticsHashSalt)
+		userID := h.phoneHasher.ConstructUserId(req.From)
+		middleware.TrackSMSRequest(c.Request.Context(), h.analyticsManager, userID, smsSession.Language, req.Body)
 	}
 
 	// Check for keywords first
@@ -110,7 +112,7 @@ func (h *SMSHandler) HandleSMS(c *gin.Context) {
 		session := h.SessionStore.GetDisambiguationSession(req.From)
 		if session != nil {
 			if err := validation.ValidateDisambiguationChoice(req.Body, len(session.StopOptions)); err != nil {
-				log.Printf("Invalid disambiguation choice from %s: %v", analytics.HashPhoneNumber(req.From, h.analyticsHashSalt), err)
+				log.Printf("Invalid disambiguation choice from %s: %v", h.phoneHasher.HashForLogs(req.From), err)
 				errorMsg := h.LocalizationManager.GetString("sms.error.invalid_choice", h.getLanguageForUser(req.From), len(session.StopOptions))
 				twiml, _ := formatters.GenerateTwiMLSMS(errorMsg)
 				c.String(http.StatusOK, twiml)
@@ -140,7 +142,7 @@ func (h *SMSHandler) HandleSMS(c *gin.Context) {
 	smsSession.ArrivalHorizonShownMinutes = 0 // new stop query — show nearest slice from scratch
 	smsSession.LastQueryTime = time.Now().Unix()
 	if err := h.SessionStore.SetSMSSession(req.From, smsSession); err != nil {
-		log.Printf("Failed to set SMS session for %s: %v", analytics.HashPhoneNumber(req.From, h.analyticsHashSalt), err)
+		log.Printf("Failed to set SMS session for %s: %v", h.phoneHasher.HashForLogs(req.From), err)
 	}
 
 	// Find all matching stops for the given ID
@@ -156,13 +158,15 @@ func (h *SMSHandler) HandleSMS(c *gin.Context) {
 		if len(matchingStops) > 0 {
 			agencyName = matchingStops[0].AgencyName
 		}
-		middleware.TrackStopLookup(c.Request.Context(), h.analyticsManager, req.From, stopID, agencyName, h.analyticsHashSalt, success, latencyMS)
+		userID := h.phoneHasher.ConstructUserId(req.From)
+		middleware.TrackStopLookup(c.Request.Context(), h.analyticsManager, userID, stopID, agencyName, success, latencyMS)
 	}
 
 	if err != nil {
 		// Track error
 		if h.analyticsManager != nil {
-			middleware.TrackError(c.Request.Context(), h.analyticsManager, req.From, "stop_lookup", err.Error(), h.analyticsHashSalt)
+			userID := h.phoneHasher.ConstructUserId(req.From)
+			middleware.TrackError(c.Request.Context(), h.analyticsManager, userID, "stop_lookup", err.Error())
 		}
 		h.ErrorHandler.HandleSMSError(c, err, language)
 		return
@@ -191,7 +195,8 @@ func (h *SMSHandler) HandleSMS(c *gin.Context) {
 		// Track disambiguation presented
 		if h.analyticsManager != nil {
 			sessionID := fmt.Sprintf("sms_%s_%d", req.From, time.Now().Unix())
-			middleware.TrackDisambiguationPresented(c.Request.Context(), h.analyticsManager, req.From, sessionID, h.analyticsHashSalt, len(matchingStops))
+			userID := h.phoneHasher.ConstructUserId(req.From)
+			middleware.TrackDisambiguationPresented(c.Request.Context(), h.analyticsManager, userID, sessionID, len(matchingStops))
 		}
 
 		twiml, _ := formatters.GenerateTwiMLSMS(disambiguationMsg)
@@ -224,12 +229,13 @@ func (h *SMSHandler) handleDisambiguationChoice(c *gin.Context, req models.Twili
 	selectedStop := session.StopOptions[choice-1]
 	h.SessionStore.ClearDisambiguationSession(req.From)
 
-	log.Printf("User %s selected stop %s: %s", analytics.HashPhoneNumber(req.From, h.analyticsHashSalt), selectedStop.FullStopID, selectedStop.DisplayText)
+	log.Printf("User %s selected stop %s: %s", h.phoneHasher.HashForLogs(req.From), selectedStop.FullStopID, selectedStop.DisplayText)
 
 	// Track disambiguation selection
 	if h.analyticsManager != nil {
 		sessionID := fmt.Sprintf("sms_%s_%d", req.From, time.Now().Unix())
-		middleware.TrackDisambiguationSelected(c.Request.Context(), h.analyticsManager, req.From, sessionID, h.analyticsHashSalt, choice, selectedStop.FullStopID)
+		userID := h.phoneHasher.ConstructUserId(req.From)
+		middleware.TrackDisambiguationSelected(c.Request.Context(), h.analyticsManager, userID, sessionID, choice, selectedStop.FullStopID)
 	}
 
 	// Get SMS session for this user to maintain consistency
@@ -285,7 +291,7 @@ func (h *SMSHandler) getAndFormatArrivalsWithStopNameAndSession(c *gin.Context, 
 	}
 	log.Printf(
 		"SMS pagination for %s: stop=%s window=%d total_arrivals=%d excluded=%d fallback=%t offset=%d page_size=%d returned=%d",
-		analytics.HashPhoneNumber(phoneNumber, h.analyticsHashSalt),
+		h.phoneHasher.HashForLogs(phoneNumber),
 		fullStopID,
 		window,
 		len(arrivalsAll),
@@ -342,7 +348,7 @@ func (h *SMSHandler) getAndFormatArrivalsWithStopNameAndSession(c *gin.Context, 
 	newSession.ArrivalHorizonShownMinutes = offset + len(arrivals)
 	if err := h.SessionStore.SetSMSSession(phoneNumber, &newSession); err != nil {
 		// Log error but still send the response
-		log.Printf("Failed to set SMS session for %s: %v", analytics.HashPhoneNumber(phoneNumber, h.analyticsHashSalt), err)
+		log.Printf("Failed to set SMS session for %s: %v", h.phoneHasher.HashForLogs(phoneNumber), err)
 	} else {
 		*session = newSession
 	}
@@ -420,7 +426,7 @@ func (h *SMSHandler) handleMoreRequest(c *gin.Context, req models.TwilioSMSReque
 	updatedSession.LastQueryTime = time.Now().Unix()
 	if err := h.SessionStore.SetSMSSession(req.From, &updatedSession); err != nil {
 		// Log error but continue to send response
-		log.Printf("Failed to set SMS session for %s: %v", analytics.HashPhoneNumber(req.From, h.analyticsHashSalt), err)
+		log.Printf("Failed to set SMS session for %s: %v", h.phoneHasher.HashForLogs(req.From), err)
 	} else {
 		*session = updatedSession
 	}
@@ -453,7 +459,7 @@ func (h *SMSHandler) handleLanguageSwitching(c *gin.Context, req models.TwilioSM
 	if newLang, found := languageMap[message]; found && h.LocalizationManager.IsSupported(newLang) {
 		session.Language = newLang
 		if err := h.SessionStore.SetSMSSession(req.From, session); err != nil {
-			log.Printf("Failed to set SMS session for %s: %v", analytics.HashPhoneNumber(req.From, h.analyticsHashSalt), err)
+			log.Printf("Failed to set SMS session for %s: %v", h.phoneHasher.HashForLogs(req.From), err)
 		}
 		switchedMsg := h.LocalizationManager.GetString("sms.language.switched", newLang)
 		twiml, _ := formatters.GenerateTwiMLSMS(switchedMsg)
@@ -502,7 +508,7 @@ func (h *SMSHandler) handleTimeQuery(c *gin.Context, req models.TwilioSMSRequest
 		updatedSession.LastQueryTime = time.Now().Unix()
 		if err := h.SessionStore.SetSMSSession(req.From, &updatedSession); err != nil {
 			// Log error but continue to send response
-			log.Printf("Failed to set SMS session for %s: %v", analytics.HashPhoneNumber(req.From, h.analyticsHashSalt), err)
+			log.Printf("Failed to set SMS session for %s: %v", h.phoneHasher.HashForLogs(req.From), err)
 		} else {
 			*session = updatedSession
 		}
@@ -554,10 +560,9 @@ func (h *SMSHandler) getLanguageForUser(phoneNumber string) string {
 }
 
 // SetAnalyticsManager sets the analytics manager for the SMS handler
-func SetAnalyticsManager(handler interface{}, manager middleware.AnalyticsManager, hashSalt string) {
+func SetAnalyticsManager(handler interface{}, manager middleware.AnalyticsManager) {
 	switch h := handler.(type) {
 	case *SMSHandler:
 		h.analyticsManager = manager
-		h.analyticsHashSalt = hashSalt
 	}
 }

--- a/handlers/sms_test.go
+++ b/handlers/sms_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"oba-twilio/privacy"
 	"strings"
 	"testing"
 	"time"
@@ -86,7 +87,7 @@ func setupSMSTestRouter() (*gin.Engine, *MockOneBusAwayClientSMS, *SMSHandler) {
 
 	mockClient := &MockOneBusAwayClientSMS{}
 	locManager := createTestManagerWithSpanish()
-	smsHandler := NewSMSHandler(mockClient, locManager)
+	smsHandler := NewSMSHandler(mockClient, locManager, privacy.NewHasher("", ""))
 
 	r := gin.New()
 	r.POST("/sms", smsHandler.HandleSMS)

--- a/handlers/voice.go
+++ b/handlers/voice.go
@@ -6,6 +6,7 @@ import (
 	"oba-twilio/handlers/voice"
 	"oba-twilio/localization"
 	"oba-twilio/middleware"
+	"oba-twilio/privacy"
 
 	"github.com/gin-gonic/gin"
 )
@@ -14,9 +15,9 @@ type VoiceHandler struct {
 	*voice.Handler
 }
 
-func NewVoiceHandler(obaClient client.OneBusAwayClientInterface, locManager *localization.LocalizationManager) *VoiceHandler {
+func NewVoiceHandler(obaClient client.OneBusAwayClientInterface, locManager *localization.LocalizationManager, phoneHasher *privacy.Hasher) *VoiceHandler {
 	return &VoiceHandler{
-		Handler: voice.NewHandler(obaClient, locManager),
+		Handler: voice.NewHandler(obaClient, locManager, phoneHasher),
 	}
 }
 
@@ -26,9 +27,9 @@ func (h *VoiceHandler) Close() {
 	}
 }
 
-func (h *VoiceHandler) SetAnalytics(analyticsManager middleware.AnalyticsManager, hashSalt string) {
+func (h *VoiceHandler) SetAnalytics(analyticsManager middleware.AnalyticsManager) {
 	if h.Handler != nil {
-		h.Handler.SetAnalytics(analyticsManager, hashSalt)
+		h.Handler.SetAnalytics(analyticsManager)
 	}
 }
 

--- a/handlers/voice/analytics_emit_test.go
+++ b/handlers/voice/analytics_emit_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"oba-twilio/privacy"
 	"strings"
 	"testing"
 	"time"
@@ -42,8 +43,10 @@ func newTestVoiceHandler(t *testing.T) (*Handler, *analytics.Manager, *analytics
 	mock := analytics.NewMockProvider()
 	require.NoError(t, mgr.RegisterProvider("mock", mock))
 
-	h := NewHandler(nil, locManager)
-	h.SetAnalytics(mgr, "test-salt")
+	phoneHasher := privacy.NewHasher(cfg.HashSalt, "")
+
+	h := NewHandler(nil, locManager, phoneHasher)
+	h.SetAnalytics(mgr)
 	return h, mgr, mock
 }
 

--- a/handlers/voice/find_stop.go
+++ b/handlers/voice/find_stop.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"oba-twilio/analytics"
 	"strconv"
 	"time"
 
@@ -60,12 +59,12 @@ func (h *Handler) bindFindStopRequest(c *gin.Context) (models.TwilioVoiceRequest
 	// A malformed call SID is logged but not fatal: the call can still proceed.
 	if req.CallSid != "" {
 		if err := validation.ValidateTwilioCallSid(req.CallSid); err != nil {
-			log.Printf("Invalid call SID from %s: %v", analytics.HashPhoneNumber(req.From, h.analyticsHashSalt), err)
+			log.Printf("Invalid call SID from %s: %v", h.phoneHasher.HashForLogs(req.From), err)
 		}
 	}
 
 	req.Digits = validation.SanitizeUserInput(req.Digits)
-	log.Printf("Received voice input from %s: %s", analytics.HashPhoneNumber(req.From, h.analyticsHashSalt), req.Digits)
+	log.Printf("Received voice input from %s: %s", h.phoneHasher.HashForLogs(req.From), req.Digits)
 
 	return req, true
 }
@@ -87,7 +86,7 @@ func (h *Handler) tryHandleDisambiguationChoice(c *gin.Context, req models.Twili
 	maxChoices := clampChoiceCount(len(session.StopOptions))
 
 	if err := validation.ValidateDisambiguationChoice(req.Digits, maxChoices); err != nil {
-		log.Printf("Invalid disambiguation choice from %s: %v", analytics.HashPhoneNumber(req.From, h.analyticsHashSalt), err)
+		log.Printf("Invalid disambiguation choice from %s: %v", h.phoneHasher.HashForLogs(req.From), err)
 		language := h.getLanguageFromRequest(c)
 		errorMsg := h.LocalizationManager.GetString("voice.error.invalid_choice", language, maxChoices)
 		h.respondVoiceSay(c, language, errorMsg)
@@ -113,7 +112,7 @@ func (h *Handler) resolveStopID(c *gin.Context, req models.TwilioVoiceRequest) (
 	}
 
 	if err := validation.ValidateStopID(stopID); err != nil {
-		log.Printf("Invalid stop ID from %s: %s, error: %v", analytics.HashPhoneNumber(req.From, h.analyticsHashSalt), stopID, err)
+		log.Printf("Invalid stop ID from %s: %s, error: %v", h.phoneHasher.HashForLogs(req.From), stopID, err)
 		language := h.getLanguageFromRequest(c)
 		errorMsg := h.LocalizationManager.GetString("voice.error.invalid_stop_id", language)
 		h.respondVoiceSay(c, language, errorMsg)
@@ -137,7 +136,8 @@ func (h *Handler) respondForStopID(c *gin.Context, req models.TwilioVoiceRequest
 		if len(matchingStops) > 0 {
 			agencyName = matchingStops[0].AgencyName
 		}
-		middleware.TrackStopLookup(c.Request.Context(), h.analyticsManager, req.From, stopID, agencyName, h.analyticsHashSalt, success, latencyMS)
+		userID := h.phoneHasher.ConstructUserId(req.From)
+		middleware.TrackStopLookup(c.Request.Context(), h.analyticsManager, userID, stopID, agencyName, success, latencyMS)
 	}
 
 	if err != nil {
@@ -275,7 +275,7 @@ func (h *Handler) handleVoiceDisambiguationChoice(c *gin.Context, req models.Twi
 	selectedStop := session.StopOptions[choice-1]
 	h.SessionStore.ClearDisambiguationSession(req.From)
 
-	log.Printf("User %s selected stop %s: %s", analytics.HashPhoneNumber(req.From, h.analyticsHashSalt), selectedStop.FullStopID, selectedStop.DisplayText)
+	log.Printf("User %s selected stop %s: %s", h.phoneHasher.HashForLogs(req.From), selectedStop.FullStopID, selectedStop.DisplayText)
 
 	h.getAndFormatVoiceArrivalsWithSession(c, req.From, selectedStop.FullStopID, 0)
 }
@@ -351,13 +351,13 @@ func (h *Handler) getAndFormatVoiceArrivalsWithSession(c *gin.Context, phoneNumb
 	language := h.getLanguageFromRequest(c)
 	log.Printf(
 		"Formatting voice response for %s: stop=%s, arrivals=%d, excluded=%d, fallback=%t",
-		analytics.HashPhoneNumber(phoneNumber, h.analyticsHashSalt), stopName, len(arrivals), excluded, fallbackUsed,
+		h.phoneHasher.HashForLogs(phoneNumber), stopName, len(arrivals), excluded, fallbackUsed,
 	)
 
 	message := formatters.FormatVoiceResponse(arrivals, stopName, h.LocalizationManager, language)
-	log.Printf("Voice message for %s: %s", analytics.HashPhoneNumber(phoneNumber, h.analyticsHashSalt), message)
+	log.Printf("Voice message for %s: %s", h.phoneHasher.HashForLogs(phoneNumber), message)
 	if message == "" {
-		log.Printf("Empty voice response generated for %s", analytics.HashPhoneNumber(phoneNumber, h.analyticsHashSalt))
+		log.Printf("Empty voice response generated for %s", h.phoneHasher.HashForLogs(phoneNumber))
 		language := h.getLanguageFromRequest(c)
 		h.ErrorHandler.HandleVoiceError(c, fmt.Errorf("failed to format voice response"), language)
 		return
@@ -369,11 +369,11 @@ func (h *Handler) getAndFormatVoiceArrivalsWithSession(c *gin.Context, phoneNumb
 		MinutesAfter: minutesAfter,
 	}
 	if err := h.SessionStore.SetVoiceSession(phoneNumber, session); err != nil {
-		log.Printf("Failed to set voice session for %s: %v", analytics.HashPhoneNumber(phoneNumber, h.analyticsHashSalt), err)
+		log.Printf("Failed to set voice session for %s: %v", h.phoneHasher.HashForLogs(phoneNumber), err)
 	}
 	menuPrompt := h.LocalizationManager.GetString("voice.menu.more_departures", language) + " " + h.LocalizationManager.GetString("voice.menu.main_menu", language)
 
-	log.Printf("Rendering TwiML for %s with message length: %d", analytics.HashPhoneNumber(phoneNumber, h.analyticsHashSalt), len(message))
+	log.Printf("Rendering TwiML for %s with message length: %d", h.phoneHasher.HashForLogs(phoneNumber), len(message))
 
 	// Create TwiML elements
 	var elements []twiml.Element
@@ -410,7 +410,7 @@ func (h *Handler) getAndFormatVoiceArrivalsWithSession(c *gin.Context, phoneNumb
 
 	// Generate TwiML
 	if twimlResult, err := twiml.Voice(elements); err != nil {
-		log.Printf("Failed to generate TwiML for %s: %v", analytics.HashPhoneNumber(phoneNumber, h.analyticsHashSalt), err)
+		log.Printf("Failed to generate TwiML for %s: %v", h.phoneHasher.HashForLogs(phoneNumber), err)
 		errorMsg := h.LocalizationManager.GetString("voice.error.template_failed", language)
 
 		// Try to generate error response
@@ -419,7 +419,7 @@ func (h *Handler) getAndFormatVoiceArrivalsWithSession(c *gin.Context, phoneNumb
 			Language: language,
 		}
 		if errorTwiml, err2 := twiml.Voice([]twiml.Element{errorSay}); err2 != nil {
-			log.Printf("Failed to generate error TwiML for %s: %v", analytics.HashPhoneNumber(phoneNumber, h.analyticsHashSalt), err2)
+			log.Printf("Failed to generate error TwiML for %s: %v", h.phoneHasher.HashForLogs(phoneNumber), err2)
 			// Use absolute fallback
 			fallback := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?><Response><Say>%s</Say></Response>`, errorMsg)
 			c.String(http.StatusOK, fallback)
@@ -428,7 +428,7 @@ func (h *Handler) getAndFormatVoiceArrivalsWithSession(c *gin.Context, phoneNumb
 		}
 		return
 	} else {
-		log.Printf("Generated TwiML for %s, length: %d", analytics.HashPhoneNumber(phoneNumber, h.analyticsHashSalt), len(twimlResult))
+		log.Printf("Generated TwiML for %s, length: %d", h.phoneHasher.HashForLogs(phoneNumber), len(twimlResult))
 		// Log first 500 chars of TwiML for debugging
 		if len(twimlResult) > 500 {
 			log.Printf("TwiML content preview: %s...", twimlResult[:500])

--- a/handlers/voice/find_stop_test.go
+++ b/handlers/voice/find_stop_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"oba-twilio/privacy"
 	"strings"
 	"testing"
 
@@ -89,7 +90,7 @@ func expectSingleStopArrivals(mockClient *mockOBAClient, digits, fullStopID, rou
 func setupFindStopHandler() (*gin.Engine, *mockOBAClient, *Handler) {
 	gin.SetMode(gin.TestMode)
 	mockClient := &mockOBAClient{}
-	h := NewHandler(mockClient, localization.NewTestManager())
+	h := NewHandler(mockClient, localization.NewTestManager(), privacy.NewHasher("", ""))
 
 	r := gin.New()
 	r.POST("/voice/find_stop", h.HandleFindStop)
@@ -290,7 +291,7 @@ func TestHandleFindStop_SingleDigitWithoutSessionTreatedAsStopID(t *testing.T) {
 }
 
 func TestParseDisambiguationChoice(t *testing.T) {
-	h := NewHandler(&mockOBAClient{}, localization.NewTestManager())
+	h := NewHandler(&mockOBAClient{}, localization.NewTestManager(), privacy.NewHasher("", ""))
 
 	assert.Equal(t, 0, h.parseDisambiguationChoice(""))
 	assert.Equal(t, 0, h.parseDisambiguationChoice("12"))
@@ -302,7 +303,7 @@ func TestParseDisambiguationChoice(t *testing.T) {
 
 func TestHandleVoiceDisambiguationChoice_NoSession(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	h := NewHandler(&mockOBAClient{}, localization.NewTestManager())
+	h := NewHandler(&mockOBAClient{}, localization.NewTestManager(), privacy.NewHasher("", ""))
 
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
@@ -316,7 +317,7 @@ func TestHandleVoiceDisambiguationChoice_NoSession(t *testing.T) {
 func TestGetAndFormatVoiceArrivals_LookupError(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	mockClient := &mockOBAClient{}
-	h := NewHandler(mockClient, localization.NewTestManager())
+	h := NewHandler(mockClient, localization.NewTestManager(), privacy.NewHasher("", ""))
 
 	mockClient.On("GetArrivalsAndDeparturesWithWindow", "1_12345", 30).Return(nil, fmt.Errorf("boom"))
 

--- a/handlers/voice/handler.go
+++ b/handlers/voice/handler.go
@@ -2,6 +2,7 @@ package voice
 
 import (
 	"oba-twilio/models"
+	"oba-twilio/privacy"
 	"oba-twilio/validation"
 
 	"github.com/gin-gonic/gin"
@@ -19,10 +20,10 @@ type Handler struct {
 	ErrorHandler        *common.ErrorHandler
 	arrivalFilterConfig common.ArrivalFilterConfig
 	analyticsManager    middleware.AnalyticsManager
-	analyticsHashSalt   string
+	phoneHasher         *privacy.Hasher
 }
 
-func NewHandler(obaClient client.OneBusAwayClientInterface, locManager *localization.LocalizationManager) *Handler {
+func NewHandler(obaClient client.OneBusAwayClientInterface, locManager *localization.LocalizationManager, phoneHasher *privacy.Hasher) *Handler {
 	return &Handler{
 		OBAClient:           obaClient,
 		SessionStore:        common.NewSessionStore(),
@@ -33,6 +34,7 @@ func NewHandler(obaClient client.OneBusAwayClientInterface, locManager *localiza
 			MaxPredictedEarlyMins: 15,
 			FallbackToUnfiltered:  true,
 		},
+		phoneHasher: phoneHasher,
 	}
 }
 
@@ -42,9 +44,8 @@ func (h *Handler) Close() {
 	}
 }
 
-func (h *Handler) SetAnalytics(analyticsManager middleware.AnalyticsManager, hashSalt string) {
+func (h *Handler) SetAnalytics(analyticsManager middleware.AnalyticsManager) {
 	h.analyticsManager = analyticsManager
-	h.analyticsHashSalt = hashSalt
 }
 
 func (h *Handler) SetArrivalFilterConfig(cfg common.ArrivalFilterConfig) {
@@ -78,7 +79,8 @@ func (h *Handler) preprocessRequest(c *gin.Context) (*models.TwilioVoiceRequest,
 
 	// Track voice request
 	if h.analyticsManager != nil {
-		middleware.TrackVoiceRequest(c.Request.Context(), h.analyticsManager, req.From, language, h.analyticsHashSalt)
+		userID := h.phoneHasher.ConstructUserId(req.From)
+		middleware.TrackVoiceRequest(c.Request.Context(), h.analyticsManager, userID, language)
 	}
 
 	return &req, nil

--- a/handlers/voice/menu_action.go
+++ b/handlers/voice/menu_action.go
@@ -3,7 +3,6 @@ package voice
 import (
 	"log"
 	"net/http"
-	"oba-twilio/analytics"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
@@ -21,10 +20,11 @@ func (h *Handler) HandleVoiceMenuAction(c *gin.Context) {
 		return
 	}
 
-	log.Printf("Received voice menu action from %s: %s", analytics.HashPhoneNumber(req.From, h.analyticsHashSalt), req.Digits)
+	log.Printf("Received voice menu action from %s: %s", h.phoneHasher.HashForLogs(req.From), req.Digits)
 
 	if h.analyticsManager != nil {
-		middleware.TrackVoiceMenuChoice(c.Request.Context(), h.analyticsManager, req.From, h.analyticsHashSalt, req.Digits)
+		userID := h.phoneHasher.ConstructUserId(req.From)
+		middleware.TrackVoiceMenuChoice(c.Request.Context(), h.analyticsManager, userID, req.Digits)
 	}
 
 	c.Header("Content-Type", "text/xml")
@@ -67,7 +67,7 @@ func (h *Handler) handleExtendDepartures(c *gin.Context, req models.TwilioVoiceR
 	// Get minutesAfter from query parameter
 	minutesAfterStr := c.Query("minutesAfter")
 	if minutesAfterStr == "" {
-		log.Printf("Missing minutesAfter parameter in request from %s", analytics.HashPhoneNumber(req.From, h.analyticsHashSalt))
+		log.Printf("Missing minutesAfter parameter in request from %s", h.phoneHasher.HashForLogs(req.From))
 		language := h.getLanguageFromRequest(c)
 		errorMsg := h.LocalizationManager.GetString("error.internal_error", language)
 		if errorMsg == "" {
@@ -87,7 +87,7 @@ func (h *Handler) handleExtendDepartures(c *gin.Context, req models.TwilioVoiceR
 
 	newMinutesAfter, err := strconv.Atoi(minutesAfterStr)
 	if err != nil {
-		log.Printf("Invalid minutesAfter parameter: %s from %s", minutesAfterStr, analytics.HashPhoneNumber(req.From, h.analyticsHashSalt))
+		log.Printf("Invalid minutesAfter parameter: %s from %s", minutesAfterStr, h.phoneHasher.HashForLogs(req.From))
 		language := h.getLanguageFromRequest(c)
 		errorMsg := h.LocalizationManager.GetString("error.internal_error", language)
 		if errorMsg == "" {
@@ -108,7 +108,7 @@ func (h *Handler) handleExtendDepartures(c *gin.Context, req models.TwilioVoiceR
 	// Update the session
 	session.MinutesAfter = newMinutesAfter
 	if err := h.SessionStore.SetVoiceSession(req.From, session); err != nil {
-		log.Printf("Failed to update voice session for %s: %v", analytics.HashPhoneNumber(req.From, h.analyticsHashSalt), err)
+		log.Printf("Failed to update voice session for %s: %v", h.phoneHasher.HashForLogs(req.From), err)
 		language := h.getLanguageFromRequest(c)
 		errorMsg := h.LocalizationManager.GetString("error.internal_error", language)
 		if errorMsg == "" {
@@ -126,7 +126,7 @@ func (h *Handler) handleExtendDepartures(c *gin.Context, req models.TwilioVoiceR
 		return
 	}
 
-	log.Printf("Extended departures window for %s to %d minutes", analytics.HashPhoneNumber(req.From, h.analyticsHashSalt), newMinutesAfter)
+	log.Printf("Extended departures window for %s to %d minutes", h.phoneHasher.HashForLogs(req.From), newMinutesAfter)
 
 	// Get arrivals with extended window
 	h.getAndFormatVoiceArrivalsWithSession(c, req.From, session.StopID, newMinutesAfter)
@@ -135,7 +135,7 @@ func (h *Handler) handleExtendDepartures(c *gin.Context, req models.TwilioVoiceR
 // handleReturnToMainMenu clears the voice session and returns to the start menu
 func (h *Handler) handleReturnToMainMenu(c *gin.Context, req models.TwilioVoiceRequest) {
 	h.SessionStore.ClearVoiceSession(req.From)
-	log.Printf("Cleared voice session for %s, returning to main menu", analytics.HashPhoneNumber(req.From, h.analyticsHashSalt))
+	log.Printf("Cleared voice session for %s, returning to main menu", h.phoneHasher.HashForLogs(req.From))
 	h.returnToMainMenu(c)
 }
 

--- a/handlers/voice/start.go
+++ b/handlers/voice/start.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"oba-twilio/analytics"
 
 	"github.com/twilio/twilio-go/twiml"
 
@@ -20,7 +19,7 @@ func (h *Handler) HandleVoiceStart(c *gin.Context) {
 
 	language := h.getLanguageFromRequest(c)
 
-	slog.Info("Received voice call", "from", analytics.HashPhoneNumber(req.From, h.analyticsHashSalt), "callSid", req.CallSid)
+	slog.Info("Received voice call", "from", h.phoneHasher.HashForLogs(req.From), "callSid", req.CallSid)
 
 	h.renderMainMenuWithLanguage(c, language)
 }

--- a/handlers/voice_menu_test.go
+++ b/handlers/voice_menu_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"oba-twilio/privacy"
 	"strings"
 	"testing"
 	"time"
@@ -117,7 +118,7 @@ func setupVoiceMenuTestRouter() (*gin.Engine, *MockOneBusAwayClientVoiceMenu, *V
 
 	mockClient := &MockOneBusAwayClientVoiceMenu{}
 	locManager := localization.NewTestManager()
-	voiceHandler := NewVoiceHandler(mockClient, locManager)
+	voiceHandler := NewVoiceHandler(mockClient, locManager, privacy.NewHasher("", ""))
 
 	r := gin.New()
 	r.POST("/voice", voiceHandler.HandleVoiceStart)
@@ -734,7 +735,7 @@ func TestSessionStore_VoiceSessionTimeout(t *testing.T) {
 func TestVoiceHandler_MenuActionWithQueryParameter(t *testing.T) {
 	mockClient := &MockOneBusAwayClientVoiceMenu{}
 	locManager := localization.NewTestManager()
-	voiceHandler := NewVoiceHandler(mockClient, locManager)
+	voiceHandler := NewVoiceHandler(mockClient, locManager, privacy.NewHasher("", ""))
 	defer voiceHandler.Close()
 
 	// Set up initial session
@@ -791,7 +792,7 @@ func TestVoiceHandler_MenuActionWithQueryParameter(t *testing.T) {
 func TestVoiceHandler_MenuActionMissingQueryParameter(t *testing.T) {
 	mockClient := &MockOneBusAwayClientVoiceMenu{}
 	locManager := localization.NewTestManager()
-	voiceHandler := NewVoiceHandler(mockClient, locManager)
+	voiceHandler := NewVoiceHandler(mockClient, locManager, privacy.NewHasher("", ""))
 	defer voiceHandler.Close()
 
 	// Set up initial session
@@ -841,7 +842,7 @@ func TestVoiceHandler_StopNameRetrievalInResponse(t *testing.T) {
 
 	mockClient := new(MockOneBusAwayClientVoiceMenu)
 	lm := localization.NewTestManager()
-	voiceHandler := NewVoiceHandler(mockClient, lm)
+	voiceHandler := NewVoiceHandler(mockClient, lm, privacy.NewHasher("", ""))
 
 	r.POST("/voice/find_stop", voiceHandler.HandleFindStop)
 
@@ -937,7 +938,7 @@ func TestVoiceHandler_StopNameRetrievalFailure(t *testing.T) {
 
 	mockClient := new(MockOneBusAwayClientVoiceMenu)
 	lm := localization.NewTestManager()
-	voiceHandler := NewVoiceHandler(mockClient, lm)
+	voiceHandler := NewVoiceHandler(mockClient, lm, privacy.NewHasher("", ""))
 
 	r.POST("/voice/find_stop", voiceHandler.HandleFindStop)
 

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log"
+	"oba-twilio/privacy"
 	"os"
 	"os/signal"
 	"strconv"
@@ -82,6 +83,7 @@ func main() {
 		analyticsConfig = analytics.DefaultConfig()
 	}
 
+	phoneHasher := privacy.NewHasher(analyticsConfig.HashSalt, os.Getenv("PHONE_LOGS_SALT"))
 	// Create analytics manager
 	analyticsManager := analytics.NewManager(analyticsConfig)
 
@@ -191,12 +193,12 @@ func main() {
 	sessionStore := common.NewImprovedSessionStore()
 	defer sessionStore.Close()
 
-	smsHandler := handlers.NewSMSHandler(obaClient, locManager)
-	voiceHandler := handlers.NewVoiceHandler(obaClient, locManager)
+	smsHandler := handlers.NewSMSHandler(obaClient, locManager, phoneHasher)
+	voiceHandler := handlers.NewVoiceHandler(obaClient, locManager, phoneHasher)
 
 	// Pass analytics manager to handlers
-	handlers.SetAnalyticsManager(smsHandler, analyticsManager, analyticsConfig.HashSalt)
-	voiceHandler.SetAnalytics(analyticsManager, analyticsConfig.HashSalt)
+	handlers.SetAnalyticsManager(smsHandler, analyticsManager)
+	voiceHandler.SetAnalytics(analyticsManager)
 
 	arrivalFilterEnabled := parseEnvBool("ARRIVAL_FILTER_ENABLED", false)
 	arrivalFilterFallback := parseEnvBool("ARRIVAL_FILTER_FALLBACK_TO_UNFILTERED", true)
@@ -240,8 +242,8 @@ func main() {
 
 	// Add analytics middleware
 	r.Use(middleware.NewAnalyticsMiddleware(analyticsManager, middleware.AnalyticsConfig{
-		Enabled:  analyticsConfig.Enabled,
-		HashSalt: analyticsConfig.HashSalt,
+		Enabled:     analyticsConfig.Enabled,
+		PhoneHasher: phoneHasher,
 	}).Handler())
 
 	// Add health check middleware

--- a/main_test.go
+++ b/main_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"oba-twilio/privacy"
 	"os"
 	"strings"
 	"testing"
@@ -118,8 +119,8 @@ func setupTestRouter() (*gin.Engine, *MockOneBusAwayClient) {
 
 	mockClient := &MockOneBusAwayClient{}
 	locManager := localization.NewTestManager()
-	smsHandler := handlers.NewSMSHandler(mockClient, locManager)
-	voiceHandler := handlers.NewVoiceHandler(mockClient, locManager)
+	smsHandler := handlers.NewSMSHandler(mockClient, locManager, privacy.NewHasher("", ""))
+	voiceHandler := handlers.NewVoiceHandler(mockClient, locManager, privacy.NewHasher("", ""))
 
 	r := gin.New()
 	r.POST("/sms", smsHandler.HandleSMS)

--- a/middleware/analytics.go
+++ b/middleware/analytics.go
@@ -3,6 +3,7 @@ package middleware
 
 import (
 	"context"
+	"oba-twilio/privacy"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -20,9 +21,8 @@ const (
 
 // AnalyticsMiddleware provides analytics tracking for HTTP requests.
 type AnalyticsMiddleware struct {
-	manager  AnalyticsManager
-	config   AnalyticsConfig
-	hashSalt string
+	manager AnalyticsManager
+	config  AnalyticsConfig
 }
 
 // AnalyticsManager defines the interface for analytics management.
@@ -32,16 +32,15 @@ type AnalyticsManager interface {
 
 // AnalyticsConfig holds configuration for analytics middleware.
 type AnalyticsConfig struct {
-	Enabled  bool
-	HashSalt string
+	Enabled     bool
+	PhoneHasher *privacy.Hasher
 }
 
 // NewAnalyticsMiddleware creates a new analytics middleware.
 func NewAnalyticsMiddleware(manager AnalyticsManager, config AnalyticsConfig) *AnalyticsMiddleware {
 	return &AnalyticsMiddleware{
-		manager:  manager,
-		config:   config,
-		hashSalt: config.HashSalt,
+		manager: manager,
+		config:  config,
 	}
 }
 
@@ -91,7 +90,7 @@ func (am *AnalyticsMiddleware) trackRequestCompletion(c *gin.Context, start time
 	phoneNumber := am.extractPhoneNumber(c)
 	userID := ""
 	if phoneNumber != "" {
-		userID = analytics.HashPhoneNumber(phoneNumber, am.hashSalt)
+		userID = am.config.PhoneHasher.ConstructUserId(phoneNumber)
 	}
 
 	// Create request completion event
@@ -145,12 +144,11 @@ func generateRequestID() string {
 // Helper functions for handlers to track specific events
 
 // TrackSMSRequest tracks an incoming SMS request.
-func TrackSMSRequest(ctx context.Context, manager AnalyticsManager, phoneNumber, language, query, salt string) {
+func TrackSMSRequest(ctx context.Context, manager AnalyticsManager, userID, language, query string) {
 	if manager == nil {
 		return
 	}
 
-	userID := analytics.HashPhoneNumber(phoneNumber, salt)
 	event := analytics.SMSRequestEvent(userID, language, query)
 
 	// Add request ID if available
@@ -166,12 +164,11 @@ func TrackSMSRequest(ctx context.Context, manager AnalyticsManager, phoneNumber,
 }
 
 // TrackVoiceMenuChoice tracks a voice menu (DTMF) selection.
-func TrackVoiceMenuChoice(ctx context.Context, manager AnalyticsManager, phoneNumber, salt, digits string) {
+func TrackVoiceMenuChoice(ctx context.Context, manager AnalyticsManager, userID, digits string) {
 	if manager == nil {
 		return
 	}
 
-	userID := analytics.HashPhoneNumber(phoneNumber, salt)
 	event := analytics.VoiceMenuChoiceEvent(userID, digits)
 
 	if requestID, ok := ctx.Value(RequestIDKey).(string); ok {
@@ -186,12 +183,11 @@ func TrackVoiceMenuChoice(ctx context.Context, manager AnalyticsManager, phoneNu
 }
 
 // TrackVoiceRequest tracks an incoming voice call.
-func TrackVoiceRequest(ctx context.Context, manager AnalyticsManager, phoneNumber, language, salt string) {
+func TrackVoiceRequest(ctx context.Context, manager AnalyticsManager, userID, language string) {
 	if manager == nil {
 		return
 	}
 
-	userID := analytics.HashPhoneNumber(phoneNumber, salt)
 	event := analytics.VoiceRequestEvent(userID, language)
 
 	// Add request ID if available
@@ -207,12 +203,11 @@ func TrackVoiceRequest(ctx context.Context, manager AnalyticsManager, phoneNumbe
 }
 
 // TrackStopLookup tracks a stop lookup attempt.
-func TrackStopLookup(ctx context.Context, manager AnalyticsManager, phoneNumber, stopID, agencyID, salt string, success bool, latencyMS int64) {
+func TrackStopLookup(ctx context.Context, manager AnalyticsManager, userID, stopID, agencyID string, success bool, latencyMS int64) {
 	if manager == nil {
 		return
 	}
 
-	userID := analytics.HashPhoneNumber(phoneNumber, salt)
 	event := analytics.StopLookupEvent(userID, stopID, agencyID, success, latencyMS)
 
 	// Add request ID if available
@@ -228,12 +223,11 @@ func TrackStopLookup(ctx context.Context, manager AnalyticsManager, phoneNumber,
 }
 
 // TrackError tracks an error occurrence.
-func TrackError(ctx context.Context, manager AnalyticsManager, phoneNumber, errorType, errorMessage, salt string) {
+func TrackError(ctx context.Context, manager AnalyticsManager, userID, errorType, errorMessage string) {
 	if manager == nil {
 		return
 	}
 
-	userID := analytics.HashPhoneNumber(phoneNumber, salt)
 	event := analytics.ErrorEvent(userID, errorType, errorMessage)
 
 	// Add request ID if available
@@ -249,12 +243,11 @@ func TrackError(ctx context.Context, manager AnalyticsManager, phoneNumber, erro
 }
 
 // TrackDisambiguationPresented tracks when multiple stop choices are shown.
-func TrackDisambiguationPresented(ctx context.Context, manager AnalyticsManager, phoneNumber, sessionID, salt string, choiceCount int) {
+func TrackDisambiguationPresented(ctx context.Context, manager AnalyticsManager, userID, sessionID string, choiceCount int) {
 	if manager == nil {
 		return
 	}
 
-	userID := analytics.HashPhoneNumber(phoneNumber, salt)
 	event := analytics.DisambiguationPresentedEvent(userID, sessionID, choiceCount)
 
 	// Add request ID if available
@@ -270,12 +263,11 @@ func TrackDisambiguationPresented(ctx context.Context, manager AnalyticsManager,
 }
 
 // TrackDisambiguationSelected tracks when a user selects from multiple stops.
-func TrackDisambiguationSelected(ctx context.Context, manager AnalyticsManager, phoneNumber, sessionID, salt string, choiceIndex int, stopID string) {
+func TrackDisambiguationSelected(ctx context.Context, manager AnalyticsManager, userID, sessionID string, choiceIndex int, stopID string) {
 	if manager == nil {
 		return
 	}
 
-	userID := analytics.HashPhoneNumber(phoneNumber, salt)
 	event := analytics.DisambiguationSelectedEvent(userID, sessionID, choiceIndex, stopID)
 
 	// Add request ID if available

--- a/middleware/analytics_test.go
+++ b/middleware/analytics_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"oba-twilio/privacy"
 	"strings"
 	"testing"
 	"time"
@@ -35,9 +36,10 @@ func (m *mockAnalyticsManager) clear() {
 
 func TestNewAnalyticsMiddleware(t *testing.T) {
 	manager := &mockAnalyticsManager{}
+	phoneHasher := privacy.NewHasher("test-salt", "")
 	config := AnalyticsConfig{
-		Enabled:  true,
-		HashSalt: "test-salt",
+		Enabled:     true,
+		PhoneHasher: phoneHasher,
 	}
 
 	middleware := NewAnalyticsMiddleware(manager, config)
@@ -45,7 +47,6 @@ func TestNewAnalyticsMiddleware(t *testing.T) {
 	assert.NotNil(t, middleware)
 	assert.Equal(t, manager, middleware.manager)
 	assert.Equal(t, config, middleware.config)
-	assert.Equal(t, config.HashSalt, middleware.hashSalt)
 }
 
 func TestAnalyticsMiddleware_HandlerDisabled(t *testing.T) {
@@ -92,9 +93,10 @@ func TestAnalyticsMiddleware_HandlerNilManager(t *testing.T) {
 
 func TestAnalyticsMiddleware_HandlerEnabled(t *testing.T) {
 	manager := &mockAnalyticsManager{}
+	phoneHasher := privacy.NewHasher("test-salt", "")
 	config := AnalyticsConfig{
-		Enabled:  true,
-		HashSalt: "test-salt",
+		Enabled:     true,
+		PhoneHasher: phoneHasher,
 	}
 
 	middleware := NewAnalyticsMiddleware(manager, config)
@@ -195,8 +197,10 @@ func TestAnalyticsMiddleware_ExtractPhoneNumber(t *testing.T) {
 func TestTrackSMSRequest(t *testing.T) {
 	manager := &mockAnalyticsManager{}
 	ctx := context.WithValue(context.Background(), RequestIDKey, "test-request-123")
+	phoneHasher := privacy.NewHasher("test-salt", "")
+	userID := phoneHasher.ConstructUserId("+12065551234")
 
-	TrackSMSRequest(ctx, manager, "+12065551234", "es-US", "75403", "test-salt")
+	TrackSMSRequest(ctx, manager, userID, "es-US", "75403")
 
 	// Give time for goroutine to complete
 	time.Sleep(50 * time.Millisecond)
@@ -216,7 +220,9 @@ func TestTrackVoiceRequest(t *testing.T) {
 	manager := &mockAnalyticsManager{}
 	ctx := context.WithValue(context.Background(), RequestIDKey, "test-request-456")
 
-	TrackVoiceRequest(ctx, manager, "+12065551234", "fr-US", "test-salt")
+	phoneHasher := privacy.NewHasher("test-salt", "")
+	userID := phoneHasher.ConstructUserId("+12065551234")
+	TrackVoiceRequest(ctx, manager, userID, "fr-US")
 
 	// Give time for goroutine to complete
 	time.Sleep(50 * time.Millisecond)
@@ -234,9 +240,11 @@ func TestTrackVoiceRequest(t *testing.T) {
 func TestTrackStopLookup(t *testing.T) {
 	manager := &mockAnalyticsManager{}
 	ctx := context.Background()
+	phoneHasher := privacy.NewHasher("test-salt", "")
+	userID := phoneHasher.ConstructUserId("+12065551234")
 
 	// Test successful lookup
-	TrackStopLookup(ctx, manager, "+12065551234", "1_75403", "1", "test-salt", true, 150)
+	TrackStopLookup(ctx, manager, userID, "1_75403", "1", true, 150)
 
 	// Give time for goroutine to complete
 	time.Sleep(50 * time.Millisecond)
@@ -253,7 +261,7 @@ func TestTrackStopLookup(t *testing.T) {
 
 	// Test failed lookup
 	manager.clear()
-	TrackStopLookup(ctx, manager, "+12065551234", "invalid", "", "test-salt", false, 50)
+	TrackStopLookup(ctx, manager, userID, "invalid", "", false, 50)
 
 	// Give time for goroutine to complete
 	time.Sleep(50 * time.Millisecond)
@@ -268,8 +276,10 @@ func TestTrackStopLookup(t *testing.T) {
 func TestTrackError(t *testing.T) {
 	manager := &mockAnalyticsManager{}
 	ctx := context.Background()
+	phoneHasher := privacy.NewHasher("test-salt", "")
+	userID := phoneHasher.ConstructUserId("+12065551234")
 
-	TrackError(ctx, manager, "+12065551234", "api_error", "connection timeout", "test-salt")
+	TrackError(ctx, manager, userID, "api_error", "connection timeout")
 
 	// Give time for goroutine to complete
 	time.Sleep(50 * time.Millisecond)
@@ -287,8 +297,10 @@ func TestTrackError(t *testing.T) {
 func TestTrackDisambiguationPresented(t *testing.T) {
 	manager := &mockAnalyticsManager{}
 	ctx := context.Background()
+	phoneHasher := privacy.NewHasher("test-salt", "")
+	userID := phoneHasher.ConstructUserId("+12065551234")
 
-	TrackDisambiguationPresented(ctx, manager, "+12065551234", "session-123", "test-salt", 3)
+	TrackDisambiguationPresented(ctx, manager, userID, "session-123", 3)
 
 	// Give time for goroutine to complete
 	time.Sleep(50 * time.Millisecond)
@@ -306,8 +318,10 @@ func TestTrackDisambiguationPresented(t *testing.T) {
 func TestTrackDisambiguationSelected(t *testing.T) {
 	manager := &mockAnalyticsManager{}
 	ctx := context.Background()
+	phoneHasher := privacy.NewHasher("test-salt", "")
+	userID := phoneHasher.ConstructUserId("+12065551234")
 
-	TrackDisambiguationSelected(ctx, manager, "+12065551234", "session-123", "test-salt", 2, "1_75403")
+	TrackDisambiguationSelected(ctx, manager, userID, "session-123", 2, "1_75403")
 
 	// Give time for goroutine to complete
 	time.Sleep(50 * time.Millisecond)
@@ -327,12 +341,15 @@ func TestTrackFunctionsWithNilManager(t *testing.T) {
 	ctx := context.Background()
 
 	// All functions should handle nil manager gracefully
-	TrackSMSRequest(ctx, nil, "+12065551234", "en-US", "75403", "salt")
-	TrackVoiceRequest(ctx, nil, "+12065551234", "en-US", "salt")
-	TrackStopLookup(ctx, nil, "+12065551234", "75403", "1", "salt", true, 100)
-	TrackError(ctx, nil, "+12065551234", "error", "message", "salt")
-	TrackDisambiguationPresented(ctx, nil, "+12065551234", "session", "salt", 3)
-	TrackDisambiguationSelected(ctx, nil, "+12065551234", "session", "salt", 1, "stop")
+	phoneHasher := privacy.NewHasher("test-salt", "")
+	userID := phoneHasher.ConstructUserId("+12065551234")
+
+	TrackSMSRequest(ctx, nil, userID, "en-US", "75403")
+	TrackVoiceRequest(ctx, nil, userID, "en-US")
+	TrackStopLookup(ctx, nil, userID, "75403", "1", true, 100)
+	TrackError(ctx, nil, userID, "error", "message")
+	TrackDisambiguationPresented(ctx, nil, userID, "session", 3)
+	TrackDisambiguationSelected(ctx, nil, userID, "session", 1, "stop")
 
 	// Should not panic
 }

--- a/privacy/phone_hasher.go
+++ b/privacy/phone_hasher.go
@@ -1,0 +1,39 @@
+package privacy
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+type Hasher struct {
+	analyticsSalt string
+	logSalt       string
+}
+
+func NewHasher(analyticsSalt, logSalt string) *Hasher {
+	return &Hasher{
+		analyticsSalt: analyticsSalt,
+		logSalt:       logSalt,
+	}
+}
+
+// hashPhoneNumber creates a privacy-preserving hash of a phone number.
+// It uses SHA256 with a salt to prevent rainbow table attacks.
+func hashPhoneNumber(phoneNumber string, salt string) string {
+	if phoneNumber == "" {
+		return ""
+	}
+	h := sha256.New()
+	h.Write([]byte(phoneNumber + salt))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// ConstructUserId returns a salted hash of the phone for analytics user identification.
+func (h *Hasher) ConstructUserId(phoneNumber string) string {
+	return hashPhoneNumber(phoneNumber, h.analyticsSalt)
+}
+
+// HashForLogs returns a salted hash of the phone for safe log output.
+func (h *Hasher) HashForLogs(phoneNumber string) string {
+	return hashPhoneNumber(phoneNumber, h.logSalt)
+}

--- a/privacy/phone_hasher_test.go
+++ b/privacy/phone_hasher_test.go
@@ -1,0 +1,167 @@
+package privacy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewHasher(t *testing.T) {
+	h := NewHasher("analytics", "logs")
+
+	assert.NotNil(t, h)
+	assert.Equal(t, "analytics", h.analyticsSalt)
+	assert.Equal(t, "logs", h.logSalt)
+}
+
+func TestHashPhone(t *testing.T) {
+	tests := []struct {
+		name        string
+		phoneNumber string
+		salt        string
+		diffSalt    bool
+	}{
+		{
+			name:        "valid phone number",
+			phoneNumber: "+12065551234",
+			salt:        "test-salt",
+		},
+		{
+			name:        "empty phone number",
+			phoneNumber: "",
+			salt:        "test-salt",
+		},
+		{
+			name:        "different salt produces different hash",
+			phoneNumber: "+12065551234",
+			salt:        "different-salt",
+			diffSalt:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := hashPhoneNumber(tt.phoneNumber, tt.salt)
+
+			if tt.phoneNumber == "" {
+				assert.Empty(t, result)
+				return
+			}
+
+			assert.NotEmpty(t, result)
+			assert.Len(t, result, 64) // SHA256 produces 64 character hex string
+
+			// Verify same input produces same output
+			assert.Equal(t, result, hashPhoneNumber(tt.phoneNumber, tt.salt))
+
+			// Verify different salt produces different hash
+			if tt.diffSalt {
+				result2 := hashPhoneNumber(tt.phoneNumber, "test-salt")
+				assert.NotEqual(t, result, result2)
+			}
+		})
+	}
+}
+func TestConstructUserId(t *testing.T) {
+	h := NewHasher("analytics-salt", "log-salt")
+
+	tests := []struct {
+		name        string
+		phoneNumber string
+		wantEmpty   bool
+	}{
+		{
+			name:        "valid phone number",
+			phoneNumber: "+20123456789",
+			wantEmpty:   false,
+		},
+		{
+			name:        "empty phone number",
+			phoneNumber: "",
+			wantEmpty:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := h.ConstructUserId(tt.phoneNumber)
+
+			if tt.wantEmpty {
+				assert.Empty(t, result)
+				return
+			}
+
+			assert.NotEmpty(t, result)
+			assert.Len(t, result, 64)
+
+			assert.Equal(t, result, h.ConstructUserId(tt.phoneNumber))
+		})
+	}
+}
+
+func TestConstructUserId_GoldenValue(t *testing.T) {
+	h := NewHasher("test-salt", "")
+
+	result := h.ConstructUserId("+15551234567")
+
+	assert.Equal(
+		t,
+		"7302da8cc30f1f26654a696738d81b25d9584f6d9146d1e3eae7ee5f20d902ad",
+		result,
+	)
+}
+
+func TestHashForLogs(t *testing.T) {
+	h := NewHasher("analytics-salt", "log-salt")
+
+	tests := []struct {
+		name        string
+		phoneNumber string
+		wantEmpty   bool
+	}{
+		{
+			name:        "valid phone number",
+			phoneNumber: "+20123456789",
+			wantEmpty:   false,
+		},
+		{
+			name:        "empty phone number",
+			phoneNumber: "",
+			wantEmpty:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := h.HashForLogs(tt.phoneNumber)
+
+			if tt.wantEmpty {
+				assert.Empty(t, result)
+				return
+			}
+
+			assert.NotEmpty(t, result)
+			assert.Len(t, result, 64)
+
+			assert.Equal(t, result, h.HashForLogs(tt.phoneNumber))
+		})
+	}
+}
+
+func TestConstructUserId_DifferentPhones(t *testing.T) {
+	h := NewHasher("analytics-salt", "log-salt")
+
+	hash1 := h.ConstructUserId("+20111111111")
+	hash2 := h.ConstructUserId("+20222222222")
+
+	assert.NotEqual(t, hash1, hash2)
+}
+
+func TestDifferentSaltsProduceDifferentHashes(t *testing.T) {
+	h := NewHasher("analytics-salt", "log-salt")
+
+	userID := h.ConstructUserId("+20123456789")
+	logHash := h.HashForLogs("+20123456789")
+
+	assert.NotEqual(t, userID, logHash)
+}

--- a/privacy/phone_hasher_test.go
+++ b/privacy/phone_hasher_test.go
@@ -106,7 +106,7 @@ func TestConstructUserId_GoldenValue(t *testing.T) {
 
 	assert.Equal(
 		t,
-		"7302da8cc30f1f26654a696738d81b25d9584f6d9146d1e3eae7ee5f20d902ad",
+		"86b053469877b271a3872cf96c5e45b6487cb222d04df6a7250bcd83533e8fa5",
 		result,
 	)
 }


### PR DESCRIPTION
closes #18 

## Pull Request Description

I had a miss understanding in the issue discussion, I thought we would generate a random salt using `rand.Text()` for example which would result in a random hash every time for the same phone number.
Instead i added an optional salt env variable independent to the analytics salt, the phone number will still be hashed but with the weakness to brute force and rainbow tables attacks

I added another package `privacy` which may be useful in the future for related privacy feature (integration with external vault secrets as an example if needed)

now both analytics and handlers depend on the privacy package

added tests and adjusted the docs

this is the best design wise solution for this in my opinion. 

Take a look and let me know @aaronbrethorst   