### PR TITLE
Serve Prometheus metrics + sensitive health on an internal-only port (9119)

### DIFF
--- a/docs/superpowers/plans/2026-06-28-internal-metrics-port.md
+++ b/docs/superpowers/plans/2026-06-28-internal-metrics-port.md
@@ -130,7 +130,7 @@ git commit -m "feat(metrics): add METRICS_PORT config helpers"
 Add to `health/handlers_test.go` (add `"strings"` to its imports):
 
 ```go
-func TestPublicLivenessHandlerOmitsInternals(t *testing.T) {
+func TestPublicProbesOmitInternals(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	manager := NewManager(WithTimeout(1*time.Second), WithSystemInfo(true))
 	manager.AddChecker(&MockHealthChecker{
@@ -140,33 +140,43 @@ func TestPublicLivenessHandlerOmitsInternals(t *testing.T) {
 	h := NewHandler(manager)
 	router := gin.New()
 	router.GET("/health", h.PublicLivenessHandler)
+	// Readiness runs the registered checker, so its full body would include the
+	// checker's "secret" metadata — proving the slim handler strips it.
+	router.GET("/health/ready", h.PublicReadinessHandler)
 
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, httptest.NewRequest("GET", "/health", nil))
+	for _, path := range []string{"/health", "/health/ready"} {
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, httptest.NewRequest("GET", path, nil))
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d", w.Code)
-	}
-	body := w.Body.String()
-	for _, leak := range []string{"system_info", "checks", "goroutines", "go_version", "metadata", "secret"} {
-		if strings.Contains(body, leak) {
-			t.Errorf("public probe leaked %q: %s", leak, body)
+		if w.Code != http.StatusOK {
+			t.Fatalf("%s: expected 200, got %d", path, w.Code)
 		}
-	}
-	var resp map[string]any
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	if resp["status"] != "healthy" {
-		t.Errorf("status = %v, want healthy", resp["status"])
+		if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+			t.Errorf("%s: expected application/json, got %s", path, ct)
+		}
+		body := w.Body.String()
+		for _, leak := range []string{"system_info", "checks", "goroutines", "go_version", "metadata", "secret"} {
+			if strings.Contains(body, leak) {
+				t.Errorf("%s leaked %q: %s", path, leak, body)
+			}
+		}
+		var resp map[string]any
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("%s unmarshal: %v", path, err)
+		}
+		if resp["status"] != "healthy" {
+			t.Errorf("%s status = %v, want healthy", path, resp["status"])
+		}
 	}
 }
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `go test ./health -run TestPublicLivenessHandlerOmitsInternals -v`
+Run: `go test ./health -run TestPublicProbesOmitInternals -v`
 Expected: FAIL — `h.PublicLivenessHandler undefined`.
+
+(`json` is already imported in `handlers_test.go`; only `strings` needs adding.)
 
 - [ ] **Step 3: Write minimal implementation**
 
@@ -192,6 +202,7 @@ func (h *Handler) PublicLivenessHandler(c *gin.Context) {
 	defer cancel()
 	status := h.manager.CheckHealthLiveness(ctx).Status
 	c.Header("Cache-Control", "no-cache, no-store, must-revalidate")
+	c.Header("Content-Type", "application/json")
 	c.JSON(statusCode(status), gin.H{"status": status})
 }
 
@@ -203,9 +214,12 @@ func (h *Handler) PublicReadinessHandler(c *gin.Context) {
 	defer cancel()
 	status := h.manager.CheckHealthReadiness(ctx).Status
 	c.Header("Cache-Control", "no-cache, no-store, must-revalidate")
+	c.Header("Content-Type", "application/json")
 	c.JSON(statusCode(status), gin.H{"status": status})
 }
 ```
+
+(The explicit `Content-Type` matches the existing handlers and keeps `TestResponseHeaders` — which asserts an exact `application/json` — green; gin would otherwise append `; charset=utf-8`.)
 
 - [ ] **Step 4: Run test to verify it passes**
 
@@ -313,6 +327,22 @@ In `TestMetricsRouteDelegatesToProvidedHandler`, change the setup line from `han
 	handler.SetupInternalRoutes(router, func(c *gin.Context) { c.String(200, "stubbed") })
 ```
 
+Re-point the two remaining direct `SetupRoutes` callers so they don't depend on the shim (it is removed in Task 4). In `TestHealthHandler_UnhealthyStatus` (~line 248) and `TestHealthHandler_DegradedStatus` (~line 282), both of which hit the public `GET /health/ready`, replace:
+
+```go
+	handler.SetupRoutes(router, func(c *gin.Context) {})
+```
+
+with:
+
+```go
+	handler.SetupPublicRoutes(router)
+```
+
+Their assertions (status code `503`/`200` and `HealthResponse.Status`) still hold: the slim body `{"status":"unhealthy"}` unmarshals into `HealthResponse.Status` correctly.
+
+After these edits, the only remaining `SetupRoutes` caller in the repo is `main.go` (via the shim), which Task 4 removes.
+
 - [ ] **Step 2: Run test to verify it fails**
 
 Run: `go test ./health -run 'TestPublicLivenessRouteIsSlim|TestPublicRouterRejectsInternalRoutes' -v`
@@ -385,13 +415,17 @@ git commit -m "feat(health): split routes into public and internal sets"
 
 - [ ] **Step 1: Write the failing test**
 
-Add to `main_test.go` (ensure imports include `net/http`, `net/http/httptest`, `github.com/gin-gonic/gin`, `oba-twilio/health`, `oba-twilio/metrics`):
+Add to `main_test.go`. `main_test.go` currently imports `net/http`, `net/http/httptest`, and `github.com/gin-gonic/gin`, but **not** `oba-twilio/health` or `oba-twilio/metrics` — add both, or Task 4 won't compile.
 
 ```go
 func TestBuildInternalEngineServesMetricsNotWebhooks(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	m := metrics.New()
-	hh := health.NewHandler(health.NewManager())
+	// A registered, healthy checker so /health/detailed reports 200 (an empty
+	// manager returns 503 because zero checks is treated as unhealthy).
+	mgr := health.NewManager()
+	mgr.AddChecker(&health.SystemHealthChecker{})
+	hh := health.NewHandler(mgr)
 	engine := buildInternalEngine(m.Handler(), hh)
 
 	// /metrics is served on the internal engine.
@@ -576,18 +610,21 @@ git commit -m "feat(metrics): serve metrics + sensitive health on internal :9119
 
 **Files:**
 - Modify: `health/handlers.go` (delete `HealthResponseMiddleware` and the `responseWriter` type it uses)
+- Modify: `health/handlers_test.go` (delete `TestHealthResponseMiddleware`, the only test caller)
 
 **Interfaces:**
-- Consumes: nothing. After Task 4 nothing references `HealthResponseMiddleware`; the `responseWriter` type is only used by it.
+- Consumes: nothing. After Task 4, `main.go` no longer wires `HealthResponseMiddleware`; the only remaining reference is its own test. The `responseWriter` type is used solely by it.
 
-- [ ] **Step 1: Confirm there are no remaining references**
+- [ ] **Step 1: Confirm the remaining references**
 
 Run: `grep -rn "HealthResponseMiddleware\|responseWriter" --include=*.go .`
-Expected: matches only the definitions in `health/handlers.go` (no callers in `main.go` or tests). If a caller remains, it was missed in Task 4 — remove it before continuing.
+Expected: matches in `health/handlers.go` (the `responseWriter` struct + `Write` method + `HealthResponseMiddleware` function) and exactly one test, `health/handlers_test.go` `TestHealthResponseMiddleware` (~line 376). There must be **no** caller in `main.go`; if one remains, it was missed in Task 4 — remove it before continuing.
 
-- [ ] **Step 2: Delete the dead code**
+- [ ] **Step 2: Delete the dead code and its test**
 
 In `health/handlers.go`, delete the `responseWriter` struct, its `Write` method, and the `HealthResponseMiddleware` function (`health/handlers.go:300-334`).
+
+In `health/handlers_test.go`, delete the `TestHealthResponseMiddleware` function (~lines 376-397).
 
 - [ ] **Step 3: Build and test**
 
@@ -602,7 +639,7 @@ Expected: all pass.
 - [ ] **Step 5: Commit**
 
 ```bash
-git add health/handlers.go
+git add health/handlers.go health/handlers_test.go
 git commit -m "refactor(health): remove dead HealthResponseMiddleware"
 ```
 

--- a/docs/superpowers/plans/2026-06-28-internal-metrics-port.md
+++ b/docs/superpowers/plans/2026-06-28-internal-metrics-port.md
@@ -1,0 +1,614 @@
+# Internal Metrics Port Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Serve Prometheus `/metrics` and the sensitive health endpoints from a separate internal-only HTTP server (default port 9119), leaving only public webhooks and status-only liveness/readiness probes on the internet-routed port.
+
+**Architecture:** The app keeps its public Gin engine on `$PORT` but converts it to an `http.Server`. A second `http.Server` on `:9119` serves a separate Gin engine carrying `/metrics` + detailed/stats/config/cache. The public probes are slimmed to status-only bodies. Both servers shut down gracefully on SIGTERM.
+
+**Tech Stack:** Go, Gin, prometheus/client_golang (`promhttp`), `net/http`.
+
+## Global Constraints
+
+- Before declaring done, these MUST pass: `make lint`, `make vet`, `make test`, `make fmt`.
+- Default metrics port: `9119`. Configurable via `METRICS_PORT`.
+- Accepted `METRICS_PORT` range: integer `1`–`65535`; anything else falls back to `9119` with a logged warning.
+- The internal server listens on `:<port>` (all interfaces) — required for Render's private network. Never loopback.
+- `METRICS_PORT` must differ from `PORT`; equal values are a fatal startup error.
+- `metrics.Metrics.Handler()` must be called exactly once (it `MustRegister`s scrape counters and panics on a second call against the same registry).
+- Follow existing patterns: config helpers mirror `parseEnvInt` in `main.go`; tests use the existing Gin `TestMode` + `httptest` style.
+
+---
+
+### Task 1: METRICS_PORT config helpers
+
+**Files:**
+- Modify: `main.go` (add `defaultMetricsPort`, `resolveMetricsPort`, `metricsPortConflicts` near the other `parseEnv*` helpers at the bottom)
+- Test: `metrics_port_test.go` (new, `package main`)
+
+**Interfaces:**
+- Produces: `resolveMetricsPort(raw string) string` — returns a valid port string or `defaultMetricsPort`. `metricsPortConflicts(metricsPort, mainPort string) bool`. `const defaultMetricsPort = "9119"`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `metrics_port_test.go`:
+
+```go
+package main
+
+import "testing"
+
+func TestResolveMetricsPort(t *testing.T) {
+	cases := []struct{ raw, want string }{
+		{"", "9119"},
+		{"9119", "9119"},
+		{"8000", "8000"},
+		{"  9200 ", "9200"},
+		{"abc", "9119"},
+		{"0", "9119"},
+		{"-5", "9119"},
+		{"70000", "9119"},
+	}
+	for _, c := range cases {
+		if got := resolveMetricsPort(c.raw); got != c.want {
+			t.Errorf("resolveMetricsPort(%q) = %q, want %q", c.raw, got, c.want)
+		}
+	}
+}
+
+func TestMetricsPortConflicts(t *testing.T) {
+	if !metricsPortConflicts("8080", "8080") {
+		t.Error("expected conflict for equal ports")
+	}
+	if metricsPortConflicts("9119", "8080") {
+		t.Error("did not expect conflict for differing ports")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test . -run 'TestResolveMetricsPort|TestMetricsPortConflicts' -v`
+Expected: FAIL — `undefined: resolveMetricsPort`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `main.go`, add after `parseEnvInt`:
+
+```go
+const defaultMetricsPort = "9119"
+
+// resolveMetricsPort validates a METRICS_PORT value. It accepts an integer in
+// [1,65535] and returns it as a canonical string; empty, non-numeric, or
+// out-of-range input falls back to defaultMetricsPort with a logged warning.
+func resolveMetricsPort(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return defaultMetricsPort
+	}
+	parsed, err := strconv.Atoi(raw)
+	if err != nil || parsed < 1 || parsed > 65535 {
+		log.Printf("Invalid METRICS_PORT=%q, using default %s", raw, defaultMetricsPort)
+		return defaultMetricsPort
+	}
+	return strconv.Itoa(parsed)
+}
+
+// metricsPortConflicts reports whether the internal metrics port collides with
+// the public server port. The two http.Servers cannot share a port.
+func metricsPortConflicts(metricsPort, mainPort string) bool {
+	return metricsPort == mainPort
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test . -run 'TestResolveMetricsPort|TestMetricsPortConflicts' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add main.go metrics_port_test.go
+git commit -m "feat(metrics): add METRICS_PORT config helpers"
+```
+
+---
+
+### Task 2: Slim public probe handlers
+
+**Files:**
+- Modify: `health/handlers.go` (add `statusCode`, `PublicLivenessHandler`, `PublicReadinessHandler`)
+- Test: `health/handlers_test.go` (add one test)
+
+**Interfaces:**
+- Consumes: existing `h.manager.CheckHealthLiveness(ctx)` / `CheckHealthReadiness(ctx)` returning `HealthResponse` with a `.Status` field of type `Status`.
+- Produces: `statusCode(s Status) int`; `(*Handler).PublicLivenessHandler(c *gin.Context)`; `(*Handler).PublicReadinessHandler(c *gin.Context)`. Bodies are `{"status": <status>}` only.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `health/handlers_test.go` (add `"strings"` to its imports):
+
+```go
+func TestPublicLivenessHandlerOmitsInternals(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	manager := NewManager(WithTimeout(1*time.Second), WithSystemInfo(true))
+	manager.AddChecker(&MockHealthChecker{
+		name:   "secret-checker",
+		result: CheckResult{Status: StatusHealthy, Message: "ok", Metadata: map[string]string{"secret": "x"}},
+	})
+	h := NewHandler(manager)
+	router := gin.New()
+	router.GET("/health", h.PublicLivenessHandler)
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, httptest.NewRequest("GET", "/health", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+	for _, leak := range []string{"system_info", "checks", "goroutines", "go_version", "metadata", "secret"} {
+		if strings.Contains(body, leak) {
+			t.Errorf("public probe leaked %q: %s", leak, body)
+		}
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp["status"] != "healthy" {
+		t.Errorf("status = %v, want healthy", resp["status"])
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./health -run TestPublicLivenessHandlerOmitsInternals -v`
+Expected: FAIL — `h.PublicLivenessHandler undefined`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `health/handlers.go`, add (the file already imports `context`, `net/http`, `time`, `gin`):
+
+```go
+// statusCode maps a health Status to the probe HTTP status code: healthy and
+// degraded are "up" (200); unhealthy is 503.
+func statusCode(s Status) int {
+	if s == StatusUnhealthy {
+		return http.StatusServiceUnavailable
+	}
+	return http.StatusOK
+}
+
+// PublicLivenessHandler is the internet-facing liveness probe. It runs the same
+// checks as HealthHandler to derive the status code but returns a status-only
+// body, so the public port never exposes SystemInfo, per-check Metadata, or
+// error strings.
+// GET /health
+func (h *Handler) PublicLivenessHandler(c *gin.Context) {
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+	defer cancel()
+	status := h.manager.CheckHealthLiveness(ctx).Status
+	c.Header("Cache-Control", "no-cache, no-store, must-revalidate")
+	c.JSON(statusCode(status), gin.H{"status": status})
+}
+
+// PublicReadinessHandler is the internet-facing readiness probe — status-only
+// body, same rationale as PublicLivenessHandler.
+// GET /health/ready
+func (h *Handler) PublicReadinessHandler(c *gin.Context) {
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 10*time.Second)
+	defer cancel()
+	status := h.manager.CheckHealthReadiness(ctx).Status
+	c.Header("Cache-Control", "no-cache, no-store, must-revalidate")
+	c.JSON(statusCode(status), gin.H{"status": status})
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./health -run TestPublicLivenessHandlerOmitsInternals -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add health/handlers.go health/handlers_test.go
+git commit -m "feat(health): add status-only public probe handlers"
+```
+
+---
+
+### Task 3: Split health routes into public and internal
+
+**Files:**
+- Modify: `health/handlers.go` (add `SetupPublicRoutes`, `SetupInternalRoutes`; convert `SetupRoutes` into a temporary shim)
+- Modify: `health/handlers_test.go` (rework `setupTestHandler`, update probe tests, add leak-guard test, point the metrics-delegation test at the new method)
+
+**Interfaces:**
+- Consumes: `h.PublicLivenessHandler`, `h.PublicReadinessHandler` (Task 2); existing `h.DetailedHandler`, `h.StatsHandler`, `h.ConfigHandler`, `h.CacheHandler`, `h.rateLimitMiddleware()`.
+- Produces: `(*Handler).SetupPublicRoutes(router *gin.Engine)`; `(*Handler).SetupInternalRoutes(router *gin.Engine, metricsHandler gin.HandlerFunc)`. `SetupRoutes` temporarily delegates to both (removed in Task 4).
+
+- [ ] **Step 1: Write the failing test**
+
+In `health/handlers_test.go`, replace the `setupTestHandler` function with:
+
+```go
+func setupTestHandler() (*Handler, *gin.Engine) {
+	gin.SetMode(gin.TestMode)
+
+	manager := NewManager(WithTimeout(1*time.Second), WithSystemInfo(true))
+	manager.AddChecker(&MockHealthChecker{
+		name:   "test-checker",
+		result: CheckResult{Status: StatusHealthy, Message: "Test is healthy"},
+	})
+
+	handler := NewHandler(manager)
+	router := gin.New()
+	handler.SetupPublicRoutes(router)
+	handler.SetupInternalRoutes(router, func(c *gin.Context) {})
+
+	return handler, router
+}
+```
+
+Replace `TestHealthHandler` and `TestReadinessHandler` with slim-body versions:
+
+```go
+func TestPublicLivenessRouteIsSlim(t *testing.T) {
+	_, router := setupTestHandler()
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, httptest.NewRequest("GET", "/health", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+	for _, leak := range []string{"checks", "system_info", "goroutines", "go_version", "metadata"} {
+		if strings.Contains(body, leak) {
+			t.Errorf("public /health leaked %q: %s", leak, body)
+		}
+	}
+	if cc := w.Header().Get("Cache-Control"); cc != "no-cache, no-store, must-revalidate" {
+		t.Errorf("expected no-cache header, got %s", cc)
+	}
+}
+
+func TestPublicReadinessRouteIsSlim(t *testing.T) {
+	_, router := setupTestHandler()
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, httptest.NewRequest("GET", "/health/ready", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if strings.Contains(w.Body.String(), "system_info") {
+		t.Errorf("public /health/ready leaked system_info: %s", w.Body.String())
+	}
+}
+
+func TestPublicRouterRejectsInternalRoutes(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := NewHandler(NewManager())
+	public := gin.New()
+	h.SetupPublicRoutes(public)
+
+	for _, path := range []string{"/metrics", "/health/detailed", "/health/config", "/health/stats"} {
+		w := httptest.NewRecorder()
+		public.ServeHTTP(w, httptest.NewRequest("GET", path, nil))
+		if w.Code != http.StatusNotFound {
+			t.Errorf("%s should be 404 on the public router, got %d", path, w.Code)
+		}
+	}
+}
+```
+
+In `TestMetricsRouteDelegatesToProvidedHandler`, change the setup line from `handler.SetupRoutes(...)` to:
+
+```go
+	handler.SetupInternalRoutes(router, func(c *gin.Context) { c.String(200, "stubbed") })
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./health -run 'TestPublicLivenessRouteIsSlim|TestPublicRouterRejectsInternalRoutes' -v`
+Expected: FAIL — `handler.SetupPublicRoutes undefined`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `health/handlers.go`, replace the existing `SetupRoutes` function with these three:
+
+```go
+// SetupPublicRoutes registers the internet-facing endpoints: status-only
+// liveness and readiness probes, rate-limited. Metrics and sensitive health
+// detail are deliberately NOT registered here — see SetupInternalRoutes.
+func (h *Handler) SetupPublicRoutes(router *gin.Engine) {
+	rateLimited := router.Group("/")
+	rateLimited.Use(h.rateLimitMiddleware())
+
+	rateLimited.GET("/health", h.PublicLivenessHandler)
+	rateLimited.GET("/health/ready", h.PublicReadinessHandler)
+}
+
+// SetupInternalRoutes registers the endpoints that must only be reachable on the
+// internal metrics port: Prometheus metrics plus detailed/stats/config/cache.
+// No rate limiting — the port is private and the scraper is trusted.
+func (h *Handler) SetupInternalRoutes(router *gin.Engine, metricsHandler gin.HandlerFunc) {
+	router.GET("/metrics", metricsHandler)
+
+	healthGroup := router.Group("/health")
+	{
+		healthGroup.GET("/detailed", h.DetailedHandler)
+		healthGroup.GET("/stats", h.StatsHandler)
+		healthGroup.GET("/config", h.ConfigHandler)
+		healthGroup.GET("/cache", h.CacheHandler)
+		healthGroup.DELETE("/cache", h.CacheHandler)
+	}
+}
+
+// SetupRoutes is a temporary shim that keeps main.go compiling during the port
+// split. It is removed once main wires the dedicated internal server.
+func (h *Handler) SetupRoutes(router *gin.Engine, metricsHandler gin.HandlerFunc) {
+	h.SetupPublicRoutes(router)
+	h.SetupInternalRoutes(router, metricsHandler)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./health -v`
+Expected: PASS (all health tests, including the reworked probe tests and the new leak guard).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add health/handlers.go health/handlers_test.go
+git commit -m "feat(health): split routes into public and internal sets"
+```
+
+---
+
+### Task 4: Wire the internal metrics server in main.go
+
+**Files:**
+- Modify: `main.go` (add `"net/http"` import; add `buildInternalEngine`; replace single-server wiring with dual `http.Server` + graceful shutdown; use `SetupPublicRoutes`; remove the `HealthResponseMiddleware` wiring; call `m.Handler()` once; update startup logging)
+- Modify: `health/handlers.go` (delete the temporary `SetupRoutes` shim)
+- Test: `main_test.go` (add `buildInternalEngine` test)
+
+**Interfaces:**
+- Consumes: `health.(*Handler).SetupInternalRoutes`, `health.(*Handler).SetupPublicRoutes`, `metrics.(*Metrics).Handler()`, `resolveMetricsPort`, `metricsPortConflicts`.
+- Produces: `buildInternalEngine(metricsHandler gin.HandlerFunc, healthHandler *health.Handler) *gin.Engine`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `main_test.go` (ensure imports include `net/http`, `net/http/httptest`, `github.com/gin-gonic/gin`, `oba-twilio/health`, `oba-twilio/metrics`):
+
+```go
+func TestBuildInternalEngineServesMetricsNotWebhooks(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	m := metrics.New()
+	hh := health.NewHandler(health.NewManager())
+	engine := buildInternalEngine(m.Handler(), hh)
+
+	// /metrics is served on the internal engine.
+	w := httptest.NewRecorder()
+	engine.ServeHTTP(w, httptest.NewRequest("GET", "/metrics", nil))
+	if w.Code != http.StatusOK {
+		t.Errorf("/metrics: got %d, want 200", w.Code)
+	}
+
+	// Detailed health is internal-only and served here.
+	w = httptest.NewRecorder()
+	engine.ServeHTTP(w, httptest.NewRequest("GET", "/health/detailed", nil))
+	if w.Code != http.StatusOK {
+		t.Errorf("/health/detailed: got %d, want 200", w.Code)
+	}
+
+	// Public webhooks are NOT on the internal engine.
+	w = httptest.NewRecorder()
+	engine.ServeHTTP(w, httptest.NewRequest("POST", "/sms", nil))
+	if w.Code != http.StatusNotFound {
+		t.Errorf("/sms on internal engine: got %d, want 404", w.Code)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test . -run TestBuildInternalEngineServesMetricsNotWebhooks -v`
+Expected: FAIL — `undefined: buildInternalEngine`.
+
+- [ ] **Step 3: Add `buildInternalEngine` and resolve config in main**
+
+In `main.go`, add `"net/http"` to the import block. Add this function near `buildInternalEngine`'s siblings (e.g. above `main`):
+
+```go
+// buildInternalEngine assembles the gin engine for the internal-only metrics
+// server: Prometheus metrics plus the sensitive health endpoints, and none of
+// the public webhook routes.
+func buildInternalEngine(metricsHandler gin.HandlerFunc, healthHandler *health.Handler) *gin.Engine {
+	engine := gin.New()
+	engine.Use(gin.Recovery())
+	healthHandler.SetupInternalRoutes(engine, metricsHandler)
+	return engine
+}
+```
+
+In `main`, just after `port` is resolved (around `main.go:48-50`), add:
+
+```go
+	metricsPort := resolveMetricsPort(os.Getenv("METRICS_PORT"))
+	if metricsPortConflicts(metricsPort, port) {
+		log.Fatalf("METRICS_PORT (%s) must differ from PORT (%s)", metricsPort, port)
+	}
+```
+
+- [ ] **Step 4: Rewire the servers**
+
+In `main.go`, in the block currently spanning the engine setup and server start (`main.go:248-309`), make these changes:
+
+Replace the middleware/route registration block:
+
+```go
+	metricsHandler := m.Handler()
+
+	r := gin.Default()
+
+	// Add analytics middleware
+	r.Use(middleware.NewAnalyticsMiddleware(analyticsManager, middleware.AnalyticsConfig{
+		Enabled:  analyticsConfig.Enabled,
+		HashSalt: analyticsConfig.HashSalt,
+	}).Handler())
+
+	// Add Prometheus metrics middleware (public engine only)
+	r.Use(m.Middleware())
+
+	// Add health check middleware
+	r.Use(healthHandler.HealthMiddleware())
+
+	// Application info endpoint
+	r.GET("/", func(c *gin.Context) {
+		coverage := obaClient.GetCoverageArea()
+		response := gin.H{
+			"message": locManager.BrandDisplayName() + " Twilio Integration",
+			"status":  "healthy",
+			"version": "1.0.0",
+		}
+
+		if coverage != nil {
+			response["coverage"] = gin.H{
+				"center_lat": coverage.CenterLat,
+				"center_lon": coverage.CenterLon,
+				"radius":     coverage.Radius,
+			}
+		}
+
+		c.JSON(200, response)
+	})
+
+	// Public probes only; metrics + detailed health live on the internal server.
+	healthHandler.SetupPublicRoutes(r)
+
+	r.POST("/sms", smsHandler.HandleSMS)
+	r.POST("/voice", voiceHandler.HandleVoiceStart)
+	r.POST("/voice/find_stop", voiceHandler.HandleFindStop)
+	r.POST("/voice/menu_action", voiceHandler.HandleVoiceMenuAction)
+
+	internalEngine := buildInternalEngine(metricsHandler, healthHandler)
+```
+
+Notes for this step:
+- Delete the old `r.Use(healthHandler.HealthResponseMiddleware())` line.
+- Delete the old `healthHandler.SetupRoutes(r, m.Handler())` line.
+- Keep `r.Use(healthHandler.HealthMiddleware())`.
+
+Replace the startup log banner and the server-start goroutine (`main.go:291-309`) with:
+
+```go
+	publicSrv := &http.Server{
+		Addr:              ":" + port,
+		Handler:           r,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	internalSrv := &http.Server{
+		Addr:              ":" + metricsPort,
+		Handler:           internalEngine,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	log.Printf("Starting public server on port %s", port)
+	log.Printf("Starting internal metrics server on port %s", metricsPort)
+	log.Printf("OneBusAway API: %s", obaBaseURL)
+	log.Printf("Public endpoints: GET / , POST /sms , POST /voice* , GET /health , GET /health/ready")
+	log.Printf("Internal endpoints (:%s): GET /metrics , GET /health/detailed , /health/stats , /health/config , /health/cache", metricsPort)
+
+	// Set up graceful shutdown
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		if err := publicSrv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Fatal("Failed to start public server:", err)
+		}
+	}()
+	go func() {
+		if err := internalSrv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Fatal("Failed to start metrics server:", err)
+		}
+	}()
+```
+
+Then, in the existing shutdown block (after `<-sigChan` and the creation of `shutdownCtx`, `main.go:311-327`), add server shutdown before the analytics flush:
+
+```go
+	log.Println("Shutting down servers...")
+	if err := publicSrv.Shutdown(shutdownCtx); err != nil {
+		log.Printf("Public server shutdown error: %v", err)
+	}
+	if err := internalSrv.Shutdown(shutdownCtx); err != nil {
+		log.Printf("Metrics server shutdown error: %v", err)
+	}
+```
+
+- [ ] **Step 5: Remove the `SetupRoutes` shim**
+
+In `health/handlers.go`, delete the temporary `SetupRoutes` function added in Task 3 (the one with the "temporary shim" comment).
+
+- [ ] **Step 6: Build and run the full suite**
+
+Run: `go build ./... && go test . ./health -v`
+Expected: PASS, including `TestBuildInternalEngineServesMetricsNotWebhooks`. Build succeeds with no unused-import or undefined-symbol errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add main.go main_test.go health/handlers.go
+git commit -m "feat(metrics): serve metrics + sensitive health on internal :9119 server"
+```
+
+---
+
+### Task 5: Remove dead HealthResponseMiddleware
+
+**Files:**
+- Modify: `health/handlers.go` (delete `HealthResponseMiddleware` and the `responseWriter` type it uses)
+
+**Interfaces:**
+- Consumes: nothing. After Task 4 nothing references `HealthResponseMiddleware`; the `responseWriter` type is only used by it.
+
+- [ ] **Step 1: Confirm there are no remaining references**
+
+Run: `grep -rn "HealthResponseMiddleware\|responseWriter" --include=*.go .`
+Expected: matches only the definitions in `health/handlers.go` (no callers in `main.go` or tests). If a caller remains, it was missed in Task 4 — remove it before continuing.
+
+- [ ] **Step 2: Delete the dead code**
+
+In `health/handlers.go`, delete the `responseWriter` struct, its `Write` method, and the `HealthResponseMiddleware` function (`health/handlers.go:300-334`).
+
+- [ ] **Step 3: Build and test**
+
+Run: `go build ./... && go test ./health`
+Expected: PASS, no unused-symbol or compile errors.
+
+- [ ] **Step 4: Full verification suite**
+
+Run: `make fmt && make lint && make vet && make test`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add health/handlers.go
+git commit -m "refactor(health): remove dead HealthResponseMiddleware"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** config helper + range + collision (Task 1); slim public probes / C1 (Task 2); route split + leak-guard test / I4 (Task 3); dual `http.Server` + graceful shutdown both / I3, single `Handler()` / I5 + I7, public-only middleware / I6, startup logging (Task 4); dead-middleware removal / N10 (Task 5); `ReadHeaderTimeout` / N6 (Task 4). N8 (`/` stays public) is a documented decision, no code change. Render port-detection confirmation (I2) is operational verification, handled at deploy time, not a code task.
+- **Render docs check (I2):** at deploy time, confirm against current Render docs that an explicitly-set `PORT` remains the sole public port when a second port is bound, and that `9119` is not a Render-reserved port. No `render.yaml` change is expected.

--- a/docs/superpowers/specs/2026-06-28-internal-metrics-port-design.md
+++ b/docs/superpowers/specs/2026-06-28-internal-metrics-port-design.md
@@ -1,0 +1,122 @@
+# Internal Metrics Port — Design
+
+**Date:** 2026-06-28
+**Status:** Approved, pending implementation
+
+## Problem
+
+The Prometheus `/metrics` endpoint and the sensitive health endpoints
+(`/health/detailed`, `/health/stats`, `/health/config`, `/health/cache`) are
+currently registered on the **public** Gin server (`$PORT`) via
+`health.SetupRoutes`. They are only rate-limited, so anyone who can reach the
+Twilio webhook port can scrape internal metrics and read configuration/cache
+state. This leaks sensitive operational information.
+
+## Goal
+
+Serve metrics and the sensitive health endpoints from a **separate, internal-only
+HTTP server** on a dedicated port (default `9119`, configurable), leaving only
+the public webhooks and bare liveness/readiness probes on the internet-routed
+port. This mirrors the existing OBA pattern of exposing JMX on an internal port
+(`1234`) that Prometheus scrapes over the private network.
+
+## Routing Split
+
+**Public server** — existing Gin engine on `$PORT` (Render-routed to the internet):
+
+- `/` (app info)
+- `POST /sms`
+- `POST /voice`, `POST /voice/find_stop`, `POST /voice/menu_action`
+- `GET /health` (liveness probe)
+- `GET /health/ready` (readiness probe)
+
+Liveness/readiness stay public so Render health checks and external uptime
+probes keep working.
+
+**Internal server** — new engine on `0.0.0.0:9119` (private network only):
+
+- `GET /metrics`
+- `GET /health/detailed`
+- `GET /health/stats`
+- `GET /health/config`
+- `GET /health/cache`, `DELETE /health/cache` (cache inspection + destructive clear)
+
+## Components / Changes
+
+### 1. Configuration
+
+- New `METRICS_PORT` env var, default `9119`.
+- Parsed by a small, testable helper (mirrors the existing `parseEnvBool`
+  pattern in `main.go`): invalid input logs a warning and falls back to `9119`.
+- The server listens on `:<port>`, which binds all interfaces — **required** for
+  Render's private network to reach it. Loopback would make it unreachable to
+  Prometheus.
+
+### 2. `health.Handler` route split
+
+Replace the single `SetupRoutes(router, metricsHandler)` with two methods:
+
+- `SetupPublicRoutes(router *gin.Engine)` — registers `/health` and
+  `/health/ready`, keeping the existing rate-limiter group.
+- `SetupInternalRoutes(router *gin.Engine, metricsHandler gin.HandlerFunc)` —
+  registers `/metrics` plus the detailed/stats/config/cache endpoints. **No rate
+  limiting** here: the port is private and the scraper is trusted, and
+  rate-limiting `/metrics` would be a scrape footgun.
+
+### 3. Internal server
+
+- Built with `gin.New()` + `gin.Recovery()` (not `gin.Default()`, so 15-second
+  scrapes don't flood the logs).
+- Wrapped in `http.Server{Addr: ":" + metricsPort, Handler: internalEngine}`.
+- The Prometheus HTTP-request middleware (`m.Middleware()`) stays **only** on the
+  public engine, so scrape traffic doesn't pollute the `http_requests_total` /
+  `http_request_duration_seconds` series — consistent with how `Middleware()`
+  already skips `/metrics`.
+
+### 4. Startup
+
+- Launch the internal server in its own goroutine via `ListenAndServe()`.
+- Treat any error other than `http.ErrServerClosed` as `log.Fatal` — a port
+  conflict on `:9119` should fail the deploy loudly, same as the main server
+  does today.
+- The public `$PORT` server is unchanged (still `r.Run(":" + port)`).
+
+### 5. Graceful shutdown
+
+- Add `internalSrv.Shutdown(shutdownCtx)` to the existing SIGINT/SIGTERM block so
+  the metrics listener drains alongside the analytics flush.
+
+### 6. Startup logging
+
+- Update the endpoint banner to show which routes are public vs. internal, and
+  log the `:9119` bind address.
+
+## Testing
+
+- `health` package:
+  - `SetupPublicRoutes` serves `/health` and `/health/ready` but returns **404
+    for `/metrics` and `/health/detailed`** — the core security regression guard.
+  - `SetupInternalRoutes` serves `/metrics` plus detailed/stats/config/cache.
+- `METRICS_PORT` parsing helper: default, valid override, invalid-fallback.
+- Update existing metrics/health tests for the split method signatures.
+
+## Error Handling
+
+- Invalid `METRICS_PORT` → log warning, use `9119`.
+- Internal `ListenAndServe` error (except `http.ErrServerClosed`) → `log.Fatal`.
+
+## Render Notes
+
+- No `render.yaml` change is strictly required for scraping. Render's private
+  network reaches any port a service binds (max 75 ports; `9119` is allowed —
+  only `10000`, `18012`, `18013`, `19099` are reserved). Prometheus addresses the
+  service as `<service>-xxxx:9119/metrics` over `render-internal.com`, mirroring
+  the JMX-on-`1234` setup.
+- Render routes only the one detected public `$PORT` to the internet, so `:9119`
+  stays private automatically.
+
+## Out of Scope (YAGNI)
+
+- On/off switch or `METRICS_ENABLED` flag — the internal server is always on.
+- Configurable bind address — fixed to all-interfaces for Render compatibility.
+- Converting the main public server from `r.Run` to `http.Server`.

--- a/docs/superpowers/specs/2026-06-28-internal-metrics-port-design.md
+++ b/docs/superpowers/specs/2026-06-28-internal-metrics-port-design.md
@@ -1,7 +1,7 @@
 # Internal Metrics Port — Design
 
 **Date:** 2026-06-28
-**Status:** Approved, pending implementation
+**Status:** Approved (incorporates architect review), pending implementation plan
 
 ## Problem
 
@@ -12,31 +12,42 @@ currently registered on the **public** Gin server (`$PORT`) via
 Twilio webhook port can scrape internal metrics and read configuration/cache
 state. This leaks sensitive operational information.
 
+Compounding this: the probes the spec originally intended to keep public
+(`/health`, `/health/ready`) are **not bare** — their JSON bodies include
+`SystemInfo` (Go version, live goroutine count, heap/GC memory stats) and
+per-checker `Metadata`/`Error`/`Message` strings (`health/manager.go:122-129`,
+`health/checkers.go:40-45`). So `/health/ready` is effectively `/health/detailed`
+minus dependency info. Hiding `/health/detailed` while leaving `/health/ready`
+public would defeat the goal.
+
 ## Goal
 
 Serve metrics and the sensitive health endpoints from a **separate, internal-only
 HTTP server** on a dedicated port (default `9119`, configurable), leaving only
-the public webhooks and bare liveness/readiness probes on the internet-routed
-port. This mirrors the existing OBA pattern of exposing JMX on an internal port
-(`1234`) that Prometheus scrapes over the private network.
+the public webhooks and **status-only** liveness/readiness probes on the
+internet-routed port. This mirrors the existing OBA pattern of exposing JMX on an
+internal port (`1234`) that Prometheus scrapes over the private network.
 
 ## Routing Split
 
-**Public server** — existing Gin engine on `$PORT` (Render-routed to the internet):
+**Public server** — `http.Server` on `$PORT` (Render-routed to the internet):
 
-- `/` (app info)
+- `/` (app info — see N8 decision below)
 - `POST /sms`
 - `POST /voice`, `POST /voice/find_stop`, `POST /voice/menu_action`
-- `GET /health` (liveness probe)
-- `GET /health/ready` (readiness probe)
+- `GET /health` (liveness probe) — **status-only body**
+- `GET /health/ready` (readiness probe) — **status-only body**
 
-Liveness/readiness stay public so Render health checks and external uptime
-probes keep working.
+The public probes run the same underlying checks (so the HTTP status code still
+reflects real health: 200 healthy/degraded, 503 unhealthy), but emit a minimal
+body `{"status":"healthy|degraded|unhealthy"}` with **no** `Checks`,
+`SystemInfo`, or `Metadata`. Render's health check and standard uptime probes
+inspect only the status code, not the body.
 
-**Internal server** — new engine on `0.0.0.0:9119` (private network only):
+**Internal server** — `http.Server` on `:9119` (all interfaces; private network only):
 
 - `GET /metrics`
-- `GET /health/detailed`
+- `GET /health/detailed` (full liveness/readiness detail lives here)
 - `GET /health/stats`
 - `GET /health/config`
 - `GET /health/cache`, `DELETE /health/cache` (cache inspection + destructive clear)
@@ -47,76 +58,137 @@ probes keep working.
 
 - New `METRICS_PORT` env var, default `9119`.
 - Parsed by a small, testable helper (mirrors the existing `parseEnvBool`
-  pattern in `main.go`): invalid input logs a warning and falls back to `9119`.
+  pattern in `main.go`). Accepted range: integer `1`–`65535`. Anything else —
+  non-numeric, `0`, negative, `> 65535` — logs a warning and falls back to
+  `9119`.
 - The server listens on `:<port>`, which binds all interfaces — **required** for
   Render's private network to reach it. Loopback would make it unreachable to
   Prometheus.
+- **Fail-fast guard:** if `METRICS_PORT == PORT`, `log.Fatal` at startup with a
+  clear message. The two servers cannot share a port, and an accidental
+  collision would otherwise surface as an opaque "address already in use".
 
-### 2. `health.Handler` route split
+### 2. Slim public probe handlers (closes the C1 leak)
+
+Add status-only public variants in the `health` package (e.g.
+`PublicLivenessHandler` / `PublicReadinessHandler`, or a shared helper that runs
+the existing `CheckHealthLiveness` / `CheckHealthReadiness` for the status code
+but writes only `{"status": <status>}`). The existing full-detail
+`HealthHandler` / `ReadinessHandler` bodies are no longer served on the public
+port; equivalent detail remains available via `/health/detailed` on `:9119`.
+
+### 3. `health.Handler` route split
 
 Replace the single `SetupRoutes(router, metricsHandler)` with two methods:
 
 - `SetupPublicRoutes(router *gin.Engine)` — registers `/health` and
-  `/health/ready`, keeping the existing rate-limiter group.
+  `/health/ready` using the **slim** handlers, keeping the existing rate-limiter
+  group.
 - `SetupInternalRoutes(router *gin.Engine, metricsHandler gin.HandlerFunc)` —
   registers `/metrics` plus the detailed/stats/config/cache endpoints. **No rate
   limiting** here: the port is private and the scraper is trusted, and
   rate-limiting `/metrics` would be a scrape footgun.
 
-### 3. Internal server
+### 4. Engine construction extracted for testability
 
-- Built with `gin.New()` + `gin.Recovery()` (not `gin.Default()`, so 15-second
-  scrapes don't flood the logs).
-- Wrapped in `http.Server{Addr: ":" + metricsPort, Handler: internalEngine}`.
-- The Prometheus HTTP-request middleware (`m.Middleware()`) stays **only** on the
-  public engine, so scrape traffic doesn't pollute the `http_requests_total` /
-  `http_request_duration_seconds` series — consistent with how `Middleware()`
-  already skips `/metrics`.
+Extract engine wiring into testable functions, e.g.
+`buildPublicEngine(...) *gin.Engine` and
+`buildInternalEngine(metricsHandler, healthHandler) *gin.Engine`, so the
+**composed** engines can be asserted in tests (not just the per-method route
+registration). This is what guards the real wiring in `main.go`.
 
-### 4. Startup
+### 5. Two `http.Server` instances + graceful shutdown
 
-- Launch the internal server in its own goroutine via `ListenAndServe()`.
-- Treat any error other than `http.ErrServerClosed` as `log.Fatal` — a port
-  conflict on `:9119` should fail the deploy loudly, same as the main server
-  does today.
-- The public `$PORT` server is unchanged (still `r.Run(":" + port)`).
+Convert **both** servers to `http.Server` (the public one moves off gin's
+`r.Run()`):
 
-### 5. Graceful shutdown
+- Each gets `Handler` = its gin engine and `ReadHeaderTimeout` set (cheap
+  slowloris hygiene; the current `r.Run` has no timeouts).
+- Launch each in its own goroutine via `ListenAndServe()`; treat any error other
+  than `http.ErrServerClosed` as `log.Fatal`.
+- On SIGINT/SIGTERM, call `Shutdown(shutdownCtx)` on **both** servers so
+  in-flight Twilio webhooks drain too — not just scrapes. (The original spec left
+  the public server on `r.Run`, which would abruptly drop in-flight webhook
+  requests while gracefully draining idempotent scrapes — a backwards priority.
+  Fixed here.)
 
-- Add `internalSrv.Shutdown(shutdownCtx)` to the existing SIGINT/SIGTERM block so
-  the metrics listener drains alongside the analytics flush.
+### 6. Metrics middleware stays public-only
 
-### 6. Startup logging
+`m.Middleware()` is registered only on the public engine, so scrape traffic
+doesn't pollute the `http_requests_total` / `http_request_duration_seconds`
+series. (It is also a no-op on the internal engine anyway, since every internal
+path is `/metrics` or `/health*`, which `Middleware()` already skips.)
 
-- Update the endpoint banner to show which routes are public vs. internal, and
-  log the `:9119` bind address.
+### 7. Metrics handler registered exactly once
+
+`m.Handler()` calls `promhttp.InstrumentMetricHandler`, which `MustRegister`s
+`promhttp_metric_handler_requests_total` / `_in_flight` on the registry and
+**panics** on a second call against the same registry. Call `m.Handler()` once
+and pass it only to the internal routes. Tests that build internal engines across
+multiple cases must use a fresh `metrics.New()` per case (or call `Handler()`
+once).
+
+### 8. Remove dead `HealthResponseMiddleware`
+
+`HealthResponseMiddleware` (`health/handlers.go:311`) wraps every response in a
+buffering writer that appends the full body into memory and then never reads it
+(the `>= 500` branch is a placeholder no-op). It runs on every public request,
+including the hot SMS/voice webhook path. Remove it and its `r.Use(...)` wiring.
+
+### 9. Startup logging
+
+Update the endpoint banner to show which routes are public vs. internal, and log
+the `:9119` bind address.
 
 ## Testing
 
 - `health` package:
-  - `SetupPublicRoutes` serves `/health` and `/health/ready` but returns **404
-    for `/metrics` and `/health/detailed`** — the core security regression guard.
+  - **Slim public probes:** the public `/health` and `/health/ready` responses
+    return the right status code but the body does **not** contain `goroutines`,
+    `go_version`, `memory`, `Checks`, or `Metadata`. This is the core C1 guard.
+  - `SetupPublicRoutes` returns **404 for `/metrics` and `/health/detailed`**.
   - `SetupInternalRoutes` serves `/metrics` plus detailed/stats/config/cache.
-- `METRICS_PORT` parsing helper: default, valid override, invalid-fallback.
-- Update existing metrics/health tests for the split method signatures.
+- **Composed-engine guard:** assert against the engine produced by
+  `buildPublicEngine` (not just `SetupPublicRoutes`) so a future re-registration
+  of internal routes on the public engine fails the test.
+- `METRICS_PORT` parsing helper: default, valid override, and each invalid case
+  (non-numeric, `0`, negative, `> 65535`) → fallback to `9119`.
+- `METRICS_PORT == PORT` collision guard (test the validation function, not the
+  fatal path).
+- Use a fresh `metrics.New()` per internal-engine test case (see component 7).
+- Update existing metrics/health tests for the split method signatures and the
+  removed middleware.
 
 ## Error Handling
 
 - Invalid `METRICS_PORT` → log warning, use `9119`.
-- Internal `ListenAndServe` error (except `http.ErrServerClosed`) → `log.Fatal`.
+- `METRICS_PORT == PORT` → `log.Fatal` at startup.
+- Either `ListenAndServe` error (except `http.ErrServerClosed`) → `log.Fatal`.
 
 ## Render Notes
 
 - No `render.yaml` change is strictly required for scraping. Render's private
-  network reaches any port a service binds (max 75 ports; `9119` is allowed —
-  only `10000`, `18012`, `18013`, `19099` are reserved). Prometheus addresses the
-  service as `<service>-xxxx:9119/metrics` over `render-internal.com`, mirroring
-  the JMX-on-`1234` setup.
-- Render routes only the one detected public `$PORT` to the internet, so `:9119`
-  stays private automatically.
+  network reaches any port a service binds, addressed as
+  `<service>-xxxx:9119/metrics` over `render-internal.com`, mirroring the
+  JMX-on-`1234` setup.
+- **Public-port routing:** Render routes the port named by the `PORT` env var (set
+  by default on Render web services) to the internet; additional bound ports stay
+  private. The public server binds exactly `$PORT`, and the `METRICS_PORT != PORT`
+  guard ensures `:9119` is always the *other* port. The implementation plan should
+  confirm against **current** Render docs (a) that an explicitly-set `PORT` is
+  honored as the sole public port when a second port is bound, and (b) the current
+  reserved-port list, since `9119` must not collide with a Render-reserved port.
+
+## Decisions
+
+- **N8 — `/` info endpoint stays public.** It exposes coverage center lat/lon
+  (derivable from public OBA data) and a static `version: "1.0.0"`. Low
+  sensitivity; left public intentionally rather than moved internal. Revisit only
+  if version disclosure becomes a concern.
 
 ## Out of Scope (YAGNI)
 
 - On/off switch or `METRICS_ENABLED` flag — the internal server is always on.
 - Configurable bind address — fixed to all-interfaces for Render compatibility.
-- Converting the main public server from `r.Run` to `http.Server`.
+- Touching `HealthMiddleware` (slow-request logger) — only the dead
+  `HealthResponseMiddleware` is removed.

--- a/health/handlers.go
+++ b/health/handlers.go
@@ -112,54 +112,6 @@ func (h *Handler) rateLimitMiddleware() gin.HandlerFunc {
 	}
 }
 
-// HealthHandler handles basic health check requests (liveness probe)
-// GET /health
-func (h *Handler) HealthHandler(c *gin.Context) {
-	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
-	defer cancel()
-
-	response := h.manager.CheckHealthLiveness(ctx)
-
-	// Determine HTTP status code based on health status
-	statusCode := http.StatusOK
-	switch response.Status {
-	case StatusHealthy:
-		statusCode = http.StatusOK
-	case StatusDegraded:
-		statusCode = http.StatusOK // Still considered "alive" for liveness probes
-	case StatusUnhealthy:
-		statusCode = http.StatusServiceUnavailable
-	}
-
-	c.Header("Cache-Control", "no-cache, no-store, must-revalidate")
-	c.Header("Content-Type", "application/json")
-	c.JSON(statusCode, response)
-}
-
-// ReadinessHandler handles readiness check requests (readiness probe)
-// GET /health/ready
-func (h *Handler) ReadinessHandler(c *gin.Context) {
-	ctx, cancel := context.WithTimeout(c.Request.Context(), 10*time.Second)
-	defer cancel()
-
-	response := h.manager.CheckHealthReadiness(ctx)
-
-	// Determine HTTP status code based on health status
-	statusCode := http.StatusOK
-	switch response.Status {
-	case StatusHealthy:
-		statusCode = http.StatusOK
-	case StatusDegraded:
-		statusCode = http.StatusOK // Still ready to serve traffic with degraded performance
-	case StatusUnhealthy:
-		statusCode = http.StatusServiceUnavailable
-	}
-
-	c.Header("Cache-Control", "no-cache, no-store, must-revalidate")
-	c.Header("Content-Type", "application/json")
-	c.JSON(statusCode, response)
-}
-
 // DetailedHandler handles detailed health check requests
 // GET /health/detailed
 func (h *Handler) DetailedHandler(c *gin.Context) {
@@ -362,10 +314,10 @@ func statusCode(s Status) int {
 	return http.StatusOK
 }
 
-// PublicLivenessHandler is the internet-facing liveness probe. It runs the same
-// checks as HealthHandler to derive the status code but returns a status-only
-// body, so the public port never exposes SystemInfo, per-check Metadata, or
-// error strings.
+// PublicLivenessHandler is the internet-facing liveness probe. It runs the
+// liveness checks to derive the status code but returns a status-only body, so
+// the public port never exposes SystemInfo, per-check Metadata, or error
+// strings.
 // GET /health
 func (h *Handler) PublicLivenessHandler(c *gin.Context) {
 	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)

--- a/health/handlers.go
+++ b/health/handlers.go
@@ -299,43 +299,6 @@ func (h *Handler) HealthMiddleware() gin.HandlerFunc {
 	}
 }
 
-// Custom response writer to capture response data
-type responseWriter struct {
-	gin.ResponseWriter
-	body []byte
-}
-
-func (w *responseWriter) Write(data []byte) (int, error) {
-	w.body = append(w.body, data...)
-	return w.ResponseWriter.Write(data)
-}
-
-// HealthResponseMiddleware captures response data for health monitoring
-func (h *Handler) HealthResponseMiddleware() gin.HandlerFunc {
-	return func(c *gin.Context) {
-		// Create custom response writer
-		writer := &responseWriter{
-			ResponseWriter: c.Writer,
-			body:           make([]byte, 0),
-		}
-		c.Writer = writer
-
-		// Process request
-		c.Next()
-
-		// Monitor response for health indicators
-		statusCode := c.Writer.Status()
-		if statusCode >= 500 {
-			// Server error - could indicate health issues
-			// In a real implementation, you might want to:
-			// - Increment error counters
-			// - Trigger alerts
-			// - Log detailed error information
-			_ = statusCode // Placeholder to satisfy linter
-		}
-	}
-}
-
 // formatDuration formats a duration for human readability
 func formatDuration(d time.Duration) string {
 	if d < time.Millisecond {

--- a/health/handlers.go
+++ b/health/handlers.go
@@ -305,8 +305,8 @@ type JSONError struct {
 	Time    time.Time `json:"timestamp"`
 }
 
-// statusCode maps a health Status to the probe HTTP status code: healthy and
-// degraded are "up" (200); unhealthy is 503.
+// statusCode maps a health Status to the probe HTTP status code: StatusUnhealthy
+// is 503; everything else (healthy, degraded, or any future status) is 200.
 func statusCode(s Status) int {
 	if s == StatusUnhealthy {
 		return http.StatusServiceUnavailable

--- a/health/handlers.go
+++ b/health/handlers.go
@@ -270,13 +270,6 @@ func (h *Handler) SetupInternalRoutes(router *gin.Engine, metricsHandler gin.Han
 	}
 }
 
-// SetupRoutes is a temporary shim that keeps main.go compiling during the port
-// split. It is removed once main wires the dedicated internal server.
-func (h *Handler) SetupRoutes(router *gin.Engine, metricsHandler gin.HandlerFunc) {
-	h.SetupPublicRoutes(router)
-	h.SetupInternalRoutes(router, metricsHandler)
-}
-
 // HealthMiddleware provides middleware for automatic health monitoring
 func (h *Handler) HealthMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {

--- a/health/handlers.go
+++ b/health/handlers.go
@@ -243,28 +243,38 @@ func (h *Handler) CacheHandler(c *gin.Context) {
 	}
 }
 
-// SetupRoutes configures health check routes on a Gin router
-func (h *Handler) SetupRoutes(router *gin.Engine, metricsHandler gin.HandlerFunc) {
-	// Apply rate limiting to all health endpoints
+// SetupPublicRoutes registers the internet-facing endpoints: status-only
+// liveness and readiness probes, rate-limited. Metrics and sensitive health
+// detail are deliberately NOT registered here — see SetupInternalRoutes.
+func (h *Handler) SetupPublicRoutes(router *gin.Engine) {
 	rateLimited := router.Group("/")
 	rateLimited.Use(h.rateLimitMiddleware())
 
-	// Basic health check (liveness probe)
-	rateLimited.GET("/health", h.HealthHandler)
+	rateLimited.GET("/health", h.PublicLivenessHandler)
+	rateLimited.GET("/health/ready", h.PublicReadinessHandler)
+}
 
-	// Health check group for organized endpoints
-	healthGroup := rateLimited.Group("/health")
+// SetupInternalRoutes registers the endpoints that must only be reachable on the
+// internal metrics port: Prometheus metrics plus detailed/stats/config/cache.
+// No rate limiting — the port is private and the scraper is trusted.
+func (h *Handler) SetupInternalRoutes(router *gin.Engine, metricsHandler gin.HandlerFunc) {
+	router.GET("/metrics", metricsHandler)
+
+	healthGroup := router.Group("/health")
 	{
-		healthGroup.GET("/ready", h.ReadinessHandler)   // Readiness probe
-		healthGroup.GET("/detailed", h.DetailedHandler) // Detailed health info
-		healthGroup.GET("/stats", h.StatsHandler)       // Basic statistics
-		healthGroup.GET("/config", h.ConfigHandler)     // Configuration info
-		healthGroup.GET("/cache", h.CacheHandler)       // Cache status
-		healthGroup.DELETE("/cache", h.CacheHandler)    // Clear cache
+		healthGroup.GET("/detailed", h.DetailedHandler)
+		healthGroup.GET("/stats", h.StatsHandler)
+		healthGroup.GET("/config", h.ConfigHandler)
+		healthGroup.GET("/cache", h.CacheHandler)
+		healthGroup.DELETE("/cache", h.CacheHandler)
 	}
+}
 
-	// Metrics endpoint (Prometheus compatible) - also rate limited
-	rateLimited.GET("/metrics", metricsHandler)
+// SetupRoutes is a temporary shim that keeps main.go compiling during the port
+// split. It is removed once main wires the dedicated internal server.
+func (h *Handler) SetupRoutes(router *gin.Engine, metricsHandler gin.HandlerFunc) {
+	h.SetupPublicRoutes(router)
+	h.SetupInternalRoutes(router, metricsHandler)
 }
 
 // HealthMiddleware provides middleware for automatic health monitoring

--- a/health/handlers.go
+++ b/health/handlers.go
@@ -386,3 +386,38 @@ type JSONError struct {
 	Message string    `json:"message,omitempty"`
 	Time    time.Time `json:"timestamp"`
 }
+
+// statusCode maps a health Status to the probe HTTP status code: healthy and
+// degraded are "up" (200); unhealthy is 503.
+func statusCode(s Status) int {
+	if s == StatusUnhealthy {
+		return http.StatusServiceUnavailable
+	}
+	return http.StatusOK
+}
+
+// PublicLivenessHandler is the internet-facing liveness probe. It runs the same
+// checks as HealthHandler to derive the status code but returns a status-only
+// body, so the public port never exposes SystemInfo, per-check Metadata, or
+// error strings.
+// GET /health
+func (h *Handler) PublicLivenessHandler(c *gin.Context) {
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+	defer cancel()
+	status := h.manager.CheckHealthLiveness(ctx).Status
+	c.Header("Cache-Control", "no-cache, no-store, must-revalidate")
+	c.Header("Content-Type", "application/json")
+	c.JSON(statusCode(status), gin.H{"status": status})
+}
+
+// PublicReadinessHandler is the internet-facing readiness probe — status-only
+// body, same rationale as PublicLivenessHandler.
+// GET /health/ready
+func (h *Handler) PublicReadinessHandler(c *gin.Context) {
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 10*time.Second)
+	defer cancel()
+	status := h.manager.CheckHealthReadiness(ctx).Status
+	c.Header("Cache-Control", "no-cache, no-store, must-revalidate")
+	c.Header("Content-Type", "application/json")
+	c.JSON(statusCode(status), gin.H{"status": status})
+}

--- a/health/handlers_test.go
+++ b/health/handlers_test.go
@@ -14,71 +14,66 @@ import (
 func setupTestHandler() (*Handler, *gin.Engine) {
 	gin.SetMode(gin.TestMode)
 
-	manager := NewManager(WithTimeout(1 * time.Second))
+	manager := NewManager(WithTimeout(1*time.Second), WithSystemInfo(true))
 	manager.AddChecker(&MockHealthChecker{
-		name: "test-checker",
-		result: CheckResult{
-			Status:  StatusHealthy,
-			Message: "Test is healthy",
-		},
+		name:   "test-checker",
+		result: CheckResult{Status: StatusHealthy, Message: "Test is healthy"},
 	})
 
 	handler := NewHandler(manager)
 	router := gin.New()
-	handler.SetupRoutes(router, func(c *gin.Context) {})
+	handler.SetupPublicRoutes(router)
+	handler.SetupInternalRoutes(router, func(c *gin.Context) {})
 
 	return handler, router
 }
 
-func TestHealthHandler(t *testing.T) {
+func TestPublicLivenessRouteIsSlim(t *testing.T) {
 	_, router := setupTestHandler()
 
-	req, _ := http.NewRequest("GET", "/health", nil)
 	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
+	router.ServeHTTP(w, httptest.NewRequest("GET", "/health", nil))
 
 	if w.Code != http.StatusOK {
-		t.Errorf("Expected status 200, got %d", w.Code)
+		t.Fatalf("expected 200, got %d", w.Code)
 	}
-
-	var response HealthResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
-		t.Fatalf("Failed to unmarshal response: %v", err)
+	body := w.Body.String()
+	for _, leak := range []string{"checks", "system_info", "goroutines", "go_version", "metadata"} {
+		if strings.Contains(body, leak) {
+			t.Errorf("public /health leaked %q: %s", leak, body)
+		}
 	}
-
-	if response.Status != StatusHealthy {
-		t.Errorf("Expected status healthy, got %s", response.Status)
-	}
-
-	if response.Checks == nil {
-		t.Error("Expected checks to be present")
-	}
-
-	// Check cache control headers
-	cacheControl := w.Header().Get("Cache-Control")
-	if cacheControl != "no-cache, no-store, must-revalidate" {
-		t.Errorf("Expected no-cache header, got %s", cacheControl)
+	if cc := w.Header().Get("Cache-Control"); cc != "no-cache, no-store, must-revalidate" {
+		t.Errorf("expected no-cache header, got %s", cc)
 	}
 }
 
-func TestReadinessHandler(t *testing.T) {
+func TestPublicReadinessRouteIsSlim(t *testing.T) {
 	_, router := setupTestHandler()
 
-	req, _ := http.NewRequest("GET", "/health/ready", nil)
 	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
+	router.ServeHTTP(w, httptest.NewRequest("GET", "/health/ready", nil))
 
 	if w.Code != http.StatusOK {
-		t.Errorf("Expected status 200, got %d", w.Code)
+		t.Fatalf("expected 200, got %d", w.Code)
 	}
-
-	var response HealthResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
-		t.Fatalf("Failed to unmarshal response: %v", err)
+	if strings.Contains(w.Body.String(), "system_info") {
+		t.Errorf("public /health/ready leaked system_info: %s", w.Body.String())
 	}
+}
 
-	if response.Status != StatusHealthy {
-		t.Errorf("Expected status healthy, got %s", response.Status)
+func TestPublicRouterRejectsInternalRoutes(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := NewHandler(NewManager())
+	public := gin.New()
+	h.SetupPublicRoutes(public)
+
+	for _, path := range []string{"/metrics", "/health/detailed", "/health/config", "/health/stats"} {
+		w := httptest.NewRecorder()
+		public.ServeHTTP(w, httptest.NewRequest("GET", path, nil))
+		if w.Code != http.StatusNotFound {
+			t.Errorf("%s should be 404 on the public router, got %d", path, w.Code)
+		}
 	}
 }
 
@@ -111,7 +106,7 @@ func TestMetricsRouteDelegatesToProvidedHandler(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
 	handler := NewHandler(NewManager())
-	handler.SetupRoutes(router, func(c *gin.Context) { c.String(200, "stubbed") })
+	handler.SetupInternalRoutes(router, func(c *gin.Context) { c.String(200, "stubbed") })
 
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, httptest.NewRequest("GET", "/metrics", nil))
@@ -246,7 +241,7 @@ func TestHealthHandler_UnhealthyStatus(t *testing.T) {
 
 	handler := NewHandler(manager)
 	router := gin.New()
-	handler.SetupRoutes(router, func(c *gin.Context) {})
+	handler.SetupPublicRoutes(router)
 
 	req, _ := http.NewRequest("GET", "/health/ready", nil)
 	w := httptest.NewRecorder()
@@ -280,7 +275,7 @@ func TestHealthHandler_DegradedStatus(t *testing.T) {
 
 	handler := NewHandler(manager)
 	router := gin.New()
-	handler.SetupRoutes(router, func(c *gin.Context) {})
+	handler.SetupPublicRoutes(router)
 
 	req, _ := http.NewRequest("GET", "/health/ready", nil)
 	w := httptest.NewRecorder()

--- a/health/handlers_test.go
+++ b/health/handlers_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -474,5 +475,45 @@ func TestConcurrentHealthRequests(t *testing.T) {
 	// Wait for all requests to complete
 	for i := 0; i < numRequests; i++ {
 		<-done
+	}
+}
+
+func TestPublicProbesOmitInternals(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	manager := NewManager(WithTimeout(1*time.Second), WithSystemInfo(true))
+	manager.AddChecker(&MockHealthChecker{
+		name:   "secret-checker",
+		result: CheckResult{Status: StatusHealthy, Message: "ok", Metadata: map[string]string{"secret": "x"}},
+	})
+	h := NewHandler(manager)
+	router := gin.New()
+	router.GET("/health", h.PublicLivenessHandler)
+	// Readiness runs the registered checker, so its full body would include the
+	// checker's "secret" metadata — proving the slim handler strips it.
+	router.GET("/health/ready", h.PublicReadinessHandler)
+
+	for _, path := range []string{"/health", "/health/ready"} {
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, httptest.NewRequest("GET", path, nil))
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("%s: expected 200, got %d", path, w.Code)
+		}
+		if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+			t.Errorf("%s: expected application/json, got %s", path, ct)
+		}
+		body := w.Body.String()
+		for _, leak := range []string{"system_info", "checks", "goroutines", "go_version", "metadata", "secret"} {
+			if strings.Contains(body, leak) {
+				t.Errorf("%s leaked %q: %s", path, leak, body)
+			}
+		}
+		var resp map[string]any
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("%s unmarshal: %v", path, err)
+		}
+		if resp["status"] != "healthy" {
+			t.Errorf("%s status = %v, want healthy", path, resp["status"])
+		}
 	}
 }

--- a/health/handlers_test.go
+++ b/health/handlers_test.go
@@ -369,29 +369,6 @@ func TestHealthMiddleware(t *testing.T) {
 	}
 }
 
-func TestHealthResponseMiddleware(t *testing.T) {
-	handler, _ := setupTestHandler()
-
-	router := gin.New()
-	router.Use(handler.HealthResponseMiddleware())
-	router.GET("/test", func(c *gin.Context) {
-		c.String(200, "test response")
-	})
-
-	req, _ := http.NewRequest("GET", "/test", nil)
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Errorf("Expected status 200, got %d", w.Code)
-	}
-
-	body := w.Body.String()
-	if body != "test response" {
-		t.Errorf("Expected 'test response', got %s", body)
-	}
-}
-
 func TestSetupMinimalRoutes(t *testing.T) {
 	handler, _ := setupTestHandler()
 

--- a/health/handlers_test.go
+++ b/health/handlers_test.go
@@ -68,11 +68,27 @@ func TestPublicRouterRejectsInternalRoutes(t *testing.T) {
 	public := gin.New()
 	h.SetupPublicRoutes(public)
 
-	for _, path := range []string{"/metrics", "/health/detailed", "/health/config", "/health/stats"} {
+	for _, path := range []string{"/metrics", "/health/detailed", "/health/config", "/health/stats", "/health/cache"} {
 		w := httptest.NewRecorder()
 		public.ServeHTTP(w, httptest.NewRequest("GET", path, nil))
 		if w.Code != http.StatusNotFound {
 			t.Errorf("%s should be 404 on the public router, got %d", path, w.Code)
+		}
+	}
+}
+
+func TestStatusCode(t *testing.T) {
+	cases := []struct {
+		status Status
+		want   int
+	}{
+		{StatusHealthy, http.StatusOK},
+		{StatusDegraded, http.StatusOK},
+		{StatusUnhealthy, http.StatusServiceUnavailable},
+	}
+	for _, c := range cases {
+		if got := statusCode(c.status); got != c.want {
+			t.Errorf("statusCode(%q) = %d, want %d", c.status, got, c.want)
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -62,8 +62,8 @@ func main() {
 	}
 
 	metricsPort := resolveMetricsPort(os.Getenv("METRICS_PORT"))
-	if metricsPortConflicts(metricsPort, port) {
-		log.Fatalf("METRICS_PORT (%s) must differ from PORT (%s)", metricsPort, port)
+	if metricsPort == port {
+		log.Fatalf("METRICS_PORT (%s) must differ from PORT (%s); the two servers cannot share a port", metricsPort, port)
 	}
 
 	obaAPIKey := os.Getenv("ONEBUSAWAY_API_KEY")
@@ -412,10 +412,4 @@ func resolveMetricsPort(raw string) string {
 		return defaultMetricsPort
 	}
 	return strconv.Itoa(parsed)
-}
-
-// metricsPortConflicts reports whether the internal metrics port collides with
-// the public server port. The two http.Servers cannot share a port.
-func metricsPortConflicts(metricsPort, mainPort string) bool {
-	return metricsPort == mainPort
 }

--- a/main.go
+++ b/main.go
@@ -357,3 +357,27 @@ func parseEnvInt(name string, defaultValue int) int {
 	}
 	return parsed
 }
+
+const defaultMetricsPort = "9119"
+
+// resolveMetricsPort validates a METRICS_PORT value. It accepts an integer in
+// [1,65535] and returns it as a canonical string; empty, non-numeric, or
+// out-of-range input falls back to defaultMetricsPort with a logged warning.
+func resolveMetricsPort(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return defaultMetricsPort
+	}
+	parsed, err := strconv.Atoi(raw)
+	if err != nil || parsed < 1 || parsed > 65535 {
+		log.Printf("Invalid METRICS_PORT=%q, using default %s", raw, defaultMetricsPort)
+		return defaultMetricsPort
+	}
+	return strconv.Itoa(parsed)
+}
+
+// metricsPortConflicts reports whether the internal metrics port collides with
+// the public server port. The two http.Servers cannot share a port.
+func metricsPortConflicts(metricsPort, mainPort string) bool {
+	return metricsPort == mainPort
+}

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"os/signal"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -347,12 +348,24 @@ func main() {
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	if err := publicSrv.Shutdown(shutdownCtx); err != nil {
-		log.Printf("Public server shutdown error: %v", err)
-	}
-	if err := internalSrv.Shutdown(shutdownCtx); err != nil {
-		log.Printf("Metrics server shutdown error: %v", err)
-	}
+	// Drain both servers concurrently so they share the deadline in parallel
+	// rather than the public server's drain starving the internal server (and
+	// the analytics flush below) of the remaining budget.
+	var shutdownWG sync.WaitGroup
+	shutdownWG.Add(2)
+	go func() {
+		defer shutdownWG.Done()
+		if err := publicSrv.Shutdown(shutdownCtx); err != nil {
+			log.Printf("Public server shutdown error: %v", err)
+		}
+	}()
+	go func() {
+		defer shutdownWG.Done()
+		if err := internalSrv.Shutdown(shutdownCtx); err != nil {
+			log.Printf("Metrics server shutdown error: %v", err)
+		}
+	}()
+	shutdownWG.Wait()
 
 	// Flush and close analytics
 	log.Println("Flushing analytics...")
@@ -399,8 +412,9 @@ func parseEnvInt(name string, defaultValue int) int {
 const defaultMetricsPort = "9119"
 
 // resolveMetricsPort validates a METRICS_PORT value. It accepts an integer in
-// [1,65535] and returns it as a canonical string; empty, non-numeric, or
-// out-of-range input falls back to defaultMetricsPort with a logged warning.
+// [1,65535] and returns it as a canonical string. An unset (empty) value
+// silently defaults to defaultMetricsPort; a non-numeric or out-of-range value
+// also defaults but emits a logged warning.
 func resolveMetricsPort(raw string) string {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log"
+	"net/http"
 	"os"
 	"os/signal"
 	"strconv"
@@ -40,6 +41,16 @@ func validateAPIKey(apiKey string) error {
 	return nil
 }
 
+// buildInternalEngine assembles the gin engine for the internal-only metrics
+// server: Prometheus metrics plus the sensitive health endpoints, and none of
+// the public webhook routes.
+func buildInternalEngine(metricsHandler gin.HandlerFunc, healthHandler *health.Handler) *gin.Engine {
+	engine := gin.New()
+	engine.Use(gin.Recovery())
+	healthHandler.SetupInternalRoutes(engine, metricsHandler)
+	return engine
+}
+
 func main() {
 	if err := godotenv.Load(); err != nil {
 		log.Println("No .env file found, using environment variables")
@@ -48,6 +59,11 @@ func main() {
 	port := os.Getenv("PORT")
 	if port == "" {
 		port = "8080"
+	}
+
+	metricsPort := resolveMetricsPort(os.Getenv("METRICS_PORT"))
+	if metricsPortConflicts(metricsPort, port) {
+		log.Fatalf("METRICS_PORT (%s) must differ from PORT (%s)", metricsPort, port)
 	}
 
 	obaAPIKey := os.Getenv("ONEBUSAWAY_API_KEY")
@@ -245,6 +261,8 @@ func main() {
 	// Create health handler
 	healthHandler := health.NewHandler(healthManager)
 
+	metricsHandler := m.Handler()
+
 	r := gin.Default()
 
 	// Add analytics middleware
@@ -253,12 +271,11 @@ func main() {
 		HashSalt: analyticsConfig.HashSalt,
 	}).Handler())
 
-	// Add Prometheus metrics middleware
+	// Add Prometheus metrics middleware (public engine only)
 	r.Use(m.Middleware())
 
 	// Add health check middleware
 	r.Use(healthHandler.HealthMiddleware())
-	r.Use(healthHandler.HealthResponseMiddleware())
 
 	// Application info endpoint
 	r.GET("/", func(c *gin.Context) {
@@ -280,41 +297,62 @@ func main() {
 		c.JSON(200, response)
 	})
 
-	// Setup comprehensive health check endpoints
-	healthHandler.SetupRoutes(r, m.Handler())
+	// Public probes only; metrics + detailed health live on the internal server.
+	healthHandler.SetupPublicRoutes(r)
 
 	r.POST("/sms", smsHandler.HandleSMS)
 	r.POST("/voice", voiceHandler.HandleVoiceStart)
 	r.POST("/voice/find_stop", voiceHandler.HandleFindStop)
 	r.POST("/voice/menu_action", voiceHandler.HandleVoiceMenuAction)
 
-	log.Printf("Starting server on port %s", port)
+	internalEngine := buildInternalEngine(metricsHandler, healthHandler)
+
+	publicSrv := &http.Server{
+		Addr:              ":" + port,
+		Handler:           r,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	internalSrv := &http.Server{
+		Addr:              ":" + metricsPort,
+		Handler:           internalEngine,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	log.Printf("Starting public server on port %s", port)
+	log.Printf("Starting internal metrics server on port %s", metricsPort)
 	log.Printf("OneBusAway API: %s", obaBaseURL)
-	log.Printf("Health check endpoints configured:")
-	log.Printf("  - GET /health (liveness probe)")
-	log.Printf("  - GET /health/ready (readiness probe)")
-	log.Printf("  - GET /health/detailed (comprehensive status)")
-	log.Printf("  - GET /metrics (Prometheus metrics)")
-	log.Printf("  - GET /health/stats (basic statistics)")
-	log.Printf("  - GET /health/config (configuration info)")
+	log.Printf("Public endpoints: GET / , POST /sms , POST /voice* , GET /health , GET /health/ready")
+	log.Printf("Internal endpoints (:%s): GET /metrics , GET /health/detailed , /health/stats , /health/config , /health/cache", metricsPort)
 
 	// Set up graceful shutdown
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 
 	go func() {
-		if err := r.Run(":" + port); err != nil {
-			log.Fatal("Failed to start server:", err)
+		if err := publicSrv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Fatal("Failed to start public server:", err)
+		}
+	}()
+	go func() {
+		if err := internalSrv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Fatal("Failed to start metrics server:", err)
 		}
 	}()
 
 	// Wait for shutdown signal
 	<-sigChan
-	log.Println("Shutting down server...")
+	log.Println("Shutting down servers...")
 
 	// Graceful shutdown with timeout
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+
+	if err := publicSrv.Shutdown(shutdownCtx); err != nil {
+		log.Printf("Public server shutdown error: %v", err)
+	}
+	if err := internalSrv.Shutdown(shutdownCtx); err != nil {
+		log.Printf("Metrics server shutdown error: %v", err)
+	}
 
 	// Flush and close analytics
 	log.Println("Flushing analytics...")

--- a/main_test.go
+++ b/main_test.go
@@ -16,7 +16,9 @@ import (
 
 	"oba-twilio/client"
 	"oba-twilio/handlers"
+	"oba-twilio/health"
 	"oba-twilio/localization"
+	"oba-twilio/metrics"
 	"oba-twilio/models"
 )
 
@@ -379,6 +381,38 @@ func TestTwiMLGeneration(t *testing.T) {
 	assert.Contains(t, body, "<?xml version=\"1.0\"")
 	assert.Contains(t, body, "<Response>")
 	assert.Contains(t, body, "</Response>")
+}
+
+func TestBuildInternalEngineServesMetricsNotWebhooks(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	m := metrics.New()
+	// A registered, healthy checker so /health/detailed reports 200 (an empty
+	// manager returns 503 because zero checks is treated as unhealthy).
+	mgr := health.NewManager()
+	mgr.AddChecker(&health.SystemHealthChecker{})
+	hh := health.NewHandler(mgr)
+	engine := buildInternalEngine(m.Handler(), hh)
+
+	// /metrics is served on the internal engine.
+	w := httptest.NewRecorder()
+	engine.ServeHTTP(w, httptest.NewRequest("GET", "/metrics", nil))
+	if w.Code != http.StatusOK {
+		t.Errorf("/metrics: got %d, want 200", w.Code)
+	}
+
+	// Detailed health is internal-only and served here.
+	w = httptest.NewRecorder()
+	engine.ServeHTTP(w, httptest.NewRequest("GET", "/health/detailed", nil))
+	if w.Code != http.StatusOK {
+		t.Errorf("/health/detailed: got %d, want 200", w.Code)
+	}
+
+	// Public webhooks are NOT on the internal engine.
+	w = httptest.NewRecorder()
+	engine.ServeHTTP(w, httptest.NewRequest("POST", "/sms", nil))
+	if w.Code != http.StatusNotFound {
+		t.Errorf("/sms on internal engine: got %d, want 404", w.Code)
+	}
 }
 
 func TestParseEnvInt(t *testing.T) {

--- a/metrics_port_test.go
+++ b/metrics_port_test.go
@@ -19,12 +19,3 @@ func TestResolveMetricsPort(t *testing.T) {
 		}
 	}
 }
-
-func TestMetricsPortConflicts(t *testing.T) {
-	if !metricsPortConflicts("8080", "8080") {
-		t.Error("expected conflict for equal ports")
-	}
-	if metricsPortConflicts("9119", "8080") {
-		t.Error("did not expect conflict for differing ports")
-	}
-}

--- a/metrics_port_test.go
+++ b/metrics_port_test.go
@@ -1,0 +1,30 @@
+package main
+
+import "testing"
+
+func TestResolveMetricsPort(t *testing.T) {
+	cases := []struct{ raw, want string }{
+		{"", "9119"},
+		{"9119", "9119"},
+		{"8000", "8000"},
+		{"  9200 ", "9200"},
+		{"abc", "9119"},
+		{"0", "9119"},
+		{"-5", "9119"},
+		{"70000", "9119"},
+	}
+	for _, c := range cases {
+		if got := resolveMetricsPort(c.raw); got != c.want {
+			t.Errorf("resolveMetricsPort(%q) = %q, want %q", c.raw, got, c.want)
+		}
+	}
+}
+
+func TestMetricsPortConflicts(t *testing.T) {
+	if !metricsPortConflicts("8080", "8080") {
+		t.Error("expected conflict for equal ports")
+	}
+	if metricsPortConflicts("9119", "8080") {
+		t.Error("did not expect conflict for differing ports")
+	}
+}

--- a/metrics_port_test.go
+++ b/metrics_port_test.go
@@ -8,6 +8,8 @@ func TestResolveMetricsPort(t *testing.T) {
 		{"9119", "9119"},
 		{"8000", "8000"},
 		{"  9200 ", "9200"},
+		{"1", "1"},         // inclusive lower bound
+		{"65535", "65535"}, // inclusive upper bound
 		{"abc", "9119"},
 		{"0", "9119"},
 		{"-5", "9119"},


### PR DESCRIPTION
## Summary

- **Moves the Prometheus `/metrics` endpoint and the sensitive health endpoints** (`/health/detailed`, `/health/stats`, `/health/config`, `/health/cache`) off the public internet-facing port onto a **separate internal-only HTTP server** (default `:9119`, configurable via `METRICS_PORT`). Previously these were only rate-limited on the public port, exposing internal metrics, config, and cache state to anyone who could reach the Twilio webhook port.
- **Slims the public liveness/readiness probes** (`/health`, `/health/ready`) to status-only bodies (`{"status":"..."}`). They previously leaked `SystemInfo` (Go version, goroutine count, memory/GC stats) and per-checker metadata — i.e. `/health/ready` was effectively `/health/detailed` on the public port. Status codes are unchanged, so Render/uptime probes keep working.
- **Runs both servers as `http.Server` with graceful shutdown.** The public server moved off gin's `r.Run()` so in-flight Twilio webhooks drain on SIGTERM; both servers shut down concurrently sharing the 30s deadline.
- **Removes dead `HealthResponseMiddleware`** (buffered every response body into memory and did nothing with it — on the hot webhook path) and the now-unused `HealthHandler`/`ReadinessHandler`.

### Render deployment
No `render.yaml` change needed. Render's private network reaches any bound port; Prometheus scrapes `<service>-xxxx:9119/metrics` over `render-internal.com`, mirroring the existing JMX-on-1234 setup. The server binds all interfaces (required for the private network); Render routes only the public `$PORT` to the internet, so `:9119` stays private. `METRICS_PORT` is validated (1–65535, falls back to 9119) and must differ from `PORT` (fatal otherwise).

## Test plan

- [x] `make fmt`, `make vet`, `make lint` (0 issues), `make test` — all green
- [x] **Ran the binary** and verified the security boundary live:
  - Public `:8099`: `/metrics`, `/health/detailed`, `/health/config` → **404**; `/health`, `/health/ready` → slim `{"status":...}` (no SystemInfo/checks)
  - Internal `:9119`: `/metrics` → **200** (Prometheus format); `/health/detailed` → served; `POST /sms` → **404**
  - SIGTERM → both servers drain + analytics flush, exit 0
- [x] New tests: leak guard (`TestPublicProbesOmitInternals`), public-router rejection of internal routes, `buildInternalEngine` isolation, `resolveMetricsPort` validation incl. inclusive boundaries, direct `statusCode` mapping

## Review notes (non-blocking judgment calls)

- **`resolveMetricsPort` falls back to 9119 (with a logged warning) on an invalid non-empty `METRICS_PORT`**, per the design spec. A reviewer argued this should instead be **fatal** for consistency with the `ONEBUSAWAY_API_KEY` and `METRICS_PORT == PORT` checks (a typo'd port silently starts on 9119 → monitoring goes dark). Kept as fallback to match the approved spec; easy to flip to fatal if preferred.
- **Public engine is wired inline in `main()`**; only `buildInternalEngine` was extracted and unit-tested. Public isolation is covered by `TestPublicRouterRejectsInternalRoutes` + the slim-body leak test, but there's no composed-public-engine regression test. Optional follow-up: extract a parallel `buildPublicEngine`.
- The internal `:9119` endpoints are unauthenticated/unrate-limited by design (trusted private scraper). Keep the port behind network isolation on any non-Render deployment.

Design spec and implementation plan are included under `docs/superpowers/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate public and internal HTTP routing for health and metrics endpoints.
  * Public health checks now return slim status-only responses.
  * Metrics and detailed health information are now served on a dedicated internal port.

* **Bug Fixes**
  * Prevented internal endpoints from being exposed on the public server.
  * Added safer handling for the metrics port, including validation and fallback behavior.
  * Improved shutdown behavior so both servers stop cleanly together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->