### PR TITLE
Fix/include default branch for session category switch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ test-verbose:
 
 # Lint the code (requires golangci-lint)
 lint:
-	golangci-lint run
+	golangci-lint run -E exhaustive
 
 # Format the code
 fmt:

--- a/formatters/response.go
+++ b/formatters/response.go
@@ -28,7 +28,7 @@ func FormatSMSResponse(arrivals []models.Arrival, stopName string, lm *localizat
 	}
 
 	if stopName != "" {
-		response.WriteString(fmt.Sprintf("%s: %s\n", stopLabel, stopName))
+		fmt.Fprintf(&response, "%s: %s\n", stopLabel, stopName)
 	}
 
 	for i, arrival := range arrivals {
@@ -257,10 +257,10 @@ func FormatDisambiguationMessage(stopOptions []models.StopOption, originalStopID
 	}
 
 	var response strings.Builder
-	response.WriteString(fmt.Sprintf("Multiple stops found for %s:\n", originalStopID))
+	fmt.Fprintf(&response, "Multiple stops found for %s:\n", originalStopID)
 
 	for i, option := range stopOptions {
-		response.WriteString(fmt.Sprintf("%d) %s\n", i+1, option.DisplayText))
+		fmt.Fprintf(&response, "%d) %s\n", i+1, option.DisplayText)
 	}
 
 	response.WriteString("Reply with the number to choose.")

--- a/handlers/common/session_store.go
+++ b/handlers/common/session_store.go
@@ -595,6 +595,8 @@ func (s *ImprovedSessionStore) ExpireSession(phoneNumber string) {
 			if ss, ok := entry.data.(*models.SMSSession); ok {
 				ss.CreatedAt = entry.createdAt
 			}
+		default:
+			panic(fmt.Sprintf("unknown sessionCategory(%d)", int(entry.sessionType)))
 		}
 
 		// Recalculate checksum with the new timestamp

--- a/handlers/common/session_store.go
+++ b/handlers/common/session_store.go
@@ -33,10 +33,12 @@ func (s sessionCategory) String() string {
 		return "voice"
 	case sms:
 		return "sms"
+	default:
+		return fmt.Sprintf("sessionCategory(%d)", int(s))
 	}
-	return "unknown"
 }
 
+// Note: A zero-valued sessionCategory is valid and corresponds to "disambiguation"
 const (
 	disambiguation sessionCategory = iota
 	voice
@@ -314,6 +316,8 @@ func (s *ImprovedSessionStore) setSession(phoneNumber string, data interface{}, 
 			ss.CreatedAt = now
 			ss.LastQueryTime = now
 		}
+	default:
+		return fmt.Errorf("unknown sessionCategory(%d)", int(sessionType))
 	}
 
 	// Store session and update LRU
@@ -482,6 +486,8 @@ func (s *ImprovedSessionStore) estimateMemoryUsage() int64 {
 			baseSize += 100 // voice sessions are small
 		case sms:
 			baseSize += 200 // SMS sessions with language strings
+		default:
+			baseSize += 150 // This is only a rough estimate for unknown session types
 		}
 	}
 
@@ -570,6 +576,8 @@ func (s *ImprovedSessionStore) ExpireSession(phoneNumber string) {
 			timeout = (SessionTimeoutMinutes + 1) * 60
 		case sms:
 			timeout = (smsSessionTimeoutMinutes + 1) * 60
+		default:
+			panic(fmt.Sprintf("unknown sessionCategory(%d)", int(entry.sessionType)))
 		}
 		entry.createdAt = time.Now().Unix() - timeout
 


### PR DESCRIPTION
## Summary
Closes #19 
- Added explicit default branches to switches that handle `sessionCategory` to provide clear fallback behavior and better debugging information and as general best practice.
- Enabled the `exhaustive` check for `golangci-lint` in the Makefile.
- Added comment clarifying zero-valued `sessionCategory` maps to `"disambiguation"`.
- Tests pass, but enabling the `exhaustive` linter revealed unrelated non-exhaustive switches elsewhere (listed below).

## Reasoning for default case logic

**`setSession()`**
Returning an error for unknown `sessionCategory` prevents silent behavior and forces the caller to handle unexpected input instead of continuing with storing an entry with no timestamps. The error formatting is consistent with that in `String()` to allow for easy debugging.

**`estimateMemoryUsage()`**
Decided to add a conservative fallback memory estimate (`baseSize += 150`) for unknown types. Only a rough estimate and added for completeness sake 

**`ExpireSession()`**
Decide to opt for a fail-fast approach and panic when an unknown sessionCategory type is supplied. Error formatting is also consistent with that in `String()` for easier debugging.

## Other notes

The `fmt.Fprintf` changes in `formatters/response.go` are small performance/clarity improvements (avoid temp string allocation).

## Testing
- Ran `make fmt`, `make vet`, `make lint`, `make test`
- All tests pass.

## Notes
`make lint` (with `-E exhaustive`) reported remaining non-exhaustive switches in other files. These are unrelated to the `sessionCategory` changes, but surfaced after enabling the exhaustive check:

- `handlers/common/errors.go:267:3`: missing cases in switch of type `models.ErrorCode`: `ErrorCodeInvalidStopID`, `ErrorCodeStopNotFound`, `ErrorCodeInvalidResponse`, `ErrorCodeValidationFailed`, `ErrorCodeInternalError` (`exhaustive`)
- `client/onebusaway.go:152:2`: missing cases in switch of type `client.CircuitState`: `CircuitClosed` (`exhaustive`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unexpected session states, providing clearer error information and preventing invalid state transitions.
  * Enhanced diagnostic output for unrecognized session categories.
* **Chores**
  * Strengthened code-quality checks to identify additional exhaustive cases during validation.
  * Streamlined response formatting while preserving existing message content and presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->